### PR TITLE
v1.5.4

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,11 +9,11 @@
             "type": "go",
             "request": "launch",
             "mode": "auto",
-            "buildFlags": "-tags cln",
+            "buildFlags": "-tags lnd",
             "program": "${workspaceFolder}/cmd/psweb/",
             "showLog": false,
             "envFile": "${workspaceFolder}/.env",
-            // "args": ["-datadir", "/home/vlad/.peerswap2"]
+            "args": ["-datadir", "/home/vlad/.peerswap2"]
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "type": "go",
             "request": "launch",
             "mode": "auto",
-            "buildFlags": "-tags cln",
+            "buildFlags": "-tags lnd",
             "program": "${workspaceFolder}/cmd/psweb/",
             "showLog": false,
             "envFile": "${workspaceFolder}/.env",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,11 +9,11 @@
             "type": "go",
             "request": "launch",
             "mode": "auto",
-            "buildFlags": "-tags lnd",
+            "buildFlags": "-tags cln",
             "program": "${workspaceFolder}/cmd/psweb/",
             "showLog": false,
             "envFile": "${workspaceFolder}/.env",
-            "args": ["-datadir", "/home/vlad/.peerswap2"]
+            //"args": ["-datadir", "/home/vlad/.peerswap2"]
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,11 +9,11 @@
             "type": "go",
             "request": "launch",
             "mode": "auto",
-            "buildFlags": "-tags lnd",
+            "buildFlags": "-tags cln",
             "program": "${workspaceFolder}/cmd/psweb/",
             "showLog": false,
             "envFile": "${workspaceFolder}/.env",
-            "args": ["-datadir", "/home/vlad/.peerswap2"]
+            // "args": ["-datadir", "/home/vlad/.peerswap2"]
         }
     ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Versions
 
+## 1.5.4
+
+- Speedup saving Auto Fees settings
+- Hide HTTPS option for Umbrel
+
 ## 1.5.3
 
 - Add automatic channel fees management

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - AF: for HTLC Fails above Low Liq % allow increasing Low Liq % threshold
 - AF: log full fee changes history, including inbound
 - AF: reduce LND load when applying auto fees
+- AF: add realized PPM chart for the channel to help decide AF parameters
 
 ## 1.5.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Speedup saving Auto Fees settings
 - Hide HTTPS option for Umbrel
+- AF: apply HTLC Fail Bumps only when Balance % < Low Liq % 
+- AF: log full fee change history, including inbound
 
 ## 1.5.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## 1.5.4
 
-- Speedup saving Auto Fees settings
 - Hide HTTPS option for Umbrel
 - AF: apply HTLC Fail Bumps only when Local % <= Low Liq % 
 - AF: for HTLC Fails above Low Liq % allow increasing Low Liq % threshold
 - AF: log full fee changes history, including inbound
+- AF: reduce LND load when applying auto fees
 
 ## 1.5.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Speedup saving Auto Fees settings
 - Hide HTTPS option for Umbrel
 - AF: apply HTLC Fail Bumps only when Balance % < Low Liq % 
-- AF: log full fee change history, including inbound
+- AF: log full fee changes history, including inbound
 
 ## 1.5.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 - Speedup saving Auto Fees settings
 - Hide HTTPS option for Umbrel
-- AF: apply HTLC Fail Bumps only when Balance % < Low Liq % 
+- AF: apply HTLC Fail Bumps only when Local % <= Low Liq % 
+- AF: for HTLC Fails above Low Liq % allow increasing Low Liq % threshold
 - AF: log full fee changes history, including inbound
 
 ## 1.5.3

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,8 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-t.me/vladgoryachev.
-All complaints will be reviewed and investigated promptly and fairly.
+https://peerswap.dev. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
 reporter of any incident.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023-2024 Vlad Goryachev
+Copyright (c) 2023-2024 Impa10r
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,4 +12,4 @@ Getblock runs a publicly available Bitcoin Core server. It is used as a fallback
 
 ## Reporting a Vulnerability
 
-If you discover any vulnerability, please contact me directly at t.me/vladgoryachev
+If you discover any vulnerability, please report it discretely to contributors.

--- a/cmd/psweb/handlers.go
+++ b/cmd/psweb/handlers.go
@@ -884,15 +884,17 @@ func afHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	chart, maxAmount := ln.PlotPPM(channelId)
-	log.Println(maxAmount)
 	if maxAmount > 0 {
 		// calculate bubble radii and apply labels
 		// max R = 20
 		for _, p := range *chart {
 			p.R = 20 * p.Amount / maxAmount
 			p.Label = "Routed: " + formatWithThousandSeparators(p.Amount) + "\nFee: " + formatWithThousandSeparators(p.Fee) + "\nPPM: " + formatWithThousandSeparators(p.PPM)
+			log.Println(p.R)
 		}
 	}
+
+	log.Println(*chart)
 
 	type Page struct {
 		Authenticated  bool

--- a/cmd/psweb/handlers.go
+++ b/cmd/psweb/handlers.go
@@ -887,7 +887,7 @@ func afHandler(w http.ResponseWriter, r *http.Request) {
 	// calculate bubble radii in 100k
 	for i, p := range *chart {
 		(*chart)[i].R = p.Amount / 100_000
-		(*chart)[i].Label = "Routed: " + formatWithThousandSeparators(p.Amount) + "\nFee: " + formatWithThousandSeparators(p.Fee) + "\nPPM: " + formatWithThousandSeparators(p.PPM)
+		(*chart)[i].Label = "Routed: " + formatWithThousandSeparators(p.Amount) + ", Fee: " + formatWithThousandSeparators(p.Fee) + ", PPM: " + formatWithThousandSeparators(p.PPM)
 	}
 
 	type Page struct {

--- a/cmd/psweb/handlers.go
+++ b/cmd/psweb/handlers.go
@@ -1620,11 +1620,14 @@ func submitHandler(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 
-			err = ln.SetFeeRate(r.FormValue("peerNodeId"), channelId, feeRate, inbound, false)
+			oldRate, err := ln.SetFeeRate(r.FormValue("peerNodeId"), channelId, feeRate, inbound, false)
 			if err != nil {
 				redirectWithError(w, r, nextPage, err)
 				return
 			}
+
+			// log change
+			ln.LogFee(channelId, oldRate, int(feeRate), inbound, true)
 
 			// all good, display confirmation
 			msg := strings.Title(r.FormValue("direction")) + " fee rate updated to " + formatSigned(feeRate)
@@ -1667,7 +1670,7 @@ func submitHandler(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 
-			err = ln.SetFeeRate(r.FormValue("peerNodeId"), channelId, feeBase, inbound, true)
+			_, err = ln.SetFeeRate(r.FormValue("peerNodeId"), channelId, feeBase, inbound, true)
 			if err != nil {
 				redirectWithError(w, r, nextPage, err)
 				return

--- a/cmd/psweb/handlers.go
+++ b/cmd/psweb/handlers.go
@@ -884,8 +884,9 @@ func afHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	chart, maxAmount := ln.PlotPPM(channelId)
+	log.Println(maxAmount)
 	if maxAmount > 0 {
-		// calculate bobble radius and apply labels
+		// calculate bubble radii and apply labels
 		// max R = 20
 		for _, p := range *chart {
 			p.R = 20 * p.Amount / maxAmount

--- a/cmd/psweb/handlers.go
+++ b/cmd/psweb/handlers.go
@@ -375,7 +375,7 @@ func peerHandler(w http.ResponseWriter, r *http.Request) {
 				rates = "*" + rates
 			}
 
-			feeLog := ln.AutoFeeLog[ch.ChannelId]
+			feeLog := ln.LastAutoFeeLog(ch.ChannelId, false)
 			if feeLog != nil {
 				rates += ", last update " + timePassedAgo(time.Unix(feeLog.TimeStamp, 0))
 				rates += " from " + formatWithThousandSeparators(uint64(feeLog.OldRate))

--- a/cmd/psweb/handlers.go
+++ b/cmd/psweb/handlers.go
@@ -889,11 +889,9 @@ func afHandler(w http.ResponseWriter, r *http.Request) {
 		// max R = 20
 		for i, p := range *chart {
 			(*chart)[i].R = 20 * p.Amount / maxAmount
-			(*chart)[i].Label = "Routed: " + formatWithThousandSeparators(p.Amount) + "\nFee: " + formatWithThousandSeparators(p.Fee) + "\nPPM: " + formatWithThousandSeparators(p.PPM)
+			(*chart)[i].Label = "Routed: " + formatWithThousandSeparators(p.Amount) + "<br>Fee: " + formatWithThousandSeparators(p.Fee) + "<br>PPM: " + formatWithThousandSeparators(p.PPM)
 		}
 	}
-
-	log.Println(*chart)
 
 	type Page struct {
 		Authenticated  bool

--- a/cmd/psweb/handlers.go
+++ b/cmd/psweb/handlers.go
@@ -883,14 +883,11 @@ func afHandler(w http.ResponseWriter, r *http.Request) {
 		popupMessage = keys[0]
 	}
 
-	chart, maxAmount := ln.PlotPPM(channelId)
-	if maxAmount > 0 {
-		// calculate bubble radii and apply labels
-		// max R = 20
-		for i, p := range *chart {
-			(*chart)[i].R = 20 * p.Amount / maxAmount
-			(*chart)[i].Label = "Routed: " + formatWithThousandSeparators(p.Amount) + "<br>Fee: " + formatWithThousandSeparators(p.Fee) + "<br>PPM: " + formatWithThousandSeparators(p.PPM)
-		}
+	chart := ln.PlotPPM(channelId)
+	// calculate bubble radii in 100k
+	for i, p := range *chart {
+		(*chart)[i].R = p.Amount / 100_000
+		(*chart)[i].Label = "Routed: " + formatWithThousandSeparators(p.Amount) + "\nFee: " + formatWithThousandSeparators(p.Fee) + "\nPPM: " + formatWithThousandSeparators(p.PPM)
 	}
 
 	type Page struct {

--- a/cmd/psweb/handlers.go
+++ b/cmd/psweb/handlers.go
@@ -889,7 +889,7 @@ func afHandler(w http.ResponseWriter, r *http.Request) {
 		// max R = 20
 		for i, p := range *chart {
 			(*chart)[i].R = 20 * p.Amount / maxAmount
-			(*chart)[i].Label = "Routed: " + formatWithThousandSeparators(p.Amount) + ", Fee: " + formatWithThousandSeparators(p.Fee) + ", PPM: " + formatWithThousandSeparators(p.PPM)
+			(*chart)[i].Label = "Routed: " + formatWithThousandSeparators(p.Amount) + "<br>Fee: " + formatWithThousandSeparators(p.Fee) + "<br>PPM: " + formatWithThousandSeparators(p.PPM)
 		}
 	}
 

--- a/cmd/psweb/handlers.go
+++ b/cmd/psweb/handlers.go
@@ -1422,6 +1422,12 @@ func submitHandler(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
+				rule.FailedMoveThreshold, err = strconv.Atoi(r.FormValue("failedMoveThreshold"))
+				if err != nil {
+					redirectWithError(w, r, "/af?", err)
+					return
+				}
+
 				rule.LowLiqPct, err = strconv.Atoi(r.FormValue("lowLiqPct"))
 				if err != nil {
 					redirectWithError(w, r, "/af?", err)

--- a/cmd/psweb/handlers.go
+++ b/cmd/psweb/handlers.go
@@ -888,7 +888,7 @@ func afHandler(w http.ResponseWriter, r *http.Request) {
 	chart := ln.PlotPPM(channelId)
 	// bubble square area reflects amount
 	for i, p := range *chart {
-		(*chart)[i].R = uint64(math.Sqrt(float64(p.Amount) / 100_000))
+		(*chart)[i].R = uint64(math.Sqrt(float64(p.Amount) / 10_000))
 		(*chart)[i].Label = "Routed: " + formatWithThousandSeparators(p.Amount) + ", Fee: " + formatWithThousandSeparators(p.Fee) + ", PPM: " + formatWithThousandSeparators(p.PPM)
 	}
 

--- a/cmd/psweb/handlers.go
+++ b/cmd/psweb/handlers.go
@@ -889,7 +889,7 @@ func afHandler(w http.ResponseWriter, r *http.Request) {
 		// max R = 20
 		for i, p := range *chart {
 			(*chart)[i].R = 20 * p.Amount / maxAmount
-			(*chart)[i].Label = "Routed: " + formatWithThousandSeparators(p.Amount) + "<br>Fee: " + formatWithThousandSeparators(p.Fee) + "<br>PPM: " + formatWithThousandSeparators(p.PPM)
+			(*chart)[i].Label = "Routed: " + formatWithThousandSeparators(p.Amount) + ", Fee: " + formatWithThousandSeparators(p.Fee) + ", PPM: " + formatWithThousandSeparators(p.PPM)
 		}
 	}
 

--- a/cmd/psweb/handlers.go
+++ b/cmd/psweb/handlers.go
@@ -6,10 +6,16 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math"
 	"net"
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
 	"peerswap-web/cmd/psweb/bitcoin"
 	"peerswap-web/cmd/psweb/config"
 	"peerswap-web/cmd/psweb/db"
@@ -17,10 +23,6 @@ import (
 	"peerswap-web/cmd/psweb/liquid"
 	"peerswap-web/cmd/psweb/ln"
 	"peerswap-web/cmd/psweb/ps"
-	"sort"
-	"strconv"
-	"strings"
-	"time"
 
 	"github.com/elementsproject/peerswap/peerswaprpc"
 	"github.com/gorilla/sessions"
@@ -884,9 +886,9 @@ func afHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	chart := ln.PlotPPM(channelId)
-	// calculate bubble radii in 100k
+	// bubble square area reflects amount
 	for i, p := range *chart {
-		(*chart)[i].R = p.Amount / 100_000
+		(*chart)[i].R = uint64(math.Sqrt(float64(p.Amount) / 100_000))
 		(*chart)[i].Label = "Routed: " + formatWithThousandSeparators(p.Amount) + ", Fee: " + formatWithThousandSeparators(p.Fee) + ", PPM: " + formatWithThousandSeparators(p.PPM)
 	}
 

--- a/cmd/psweb/handlers.go
+++ b/cmd/psweb/handlers.go
@@ -887,10 +887,9 @@ func afHandler(w http.ResponseWriter, r *http.Request) {
 	if maxAmount > 0 {
 		// calculate bubble radii and apply labels
 		// max R = 20
-		for _, p := range *chart {
-			p.R = 20 * p.Amount / maxAmount
-			p.Label = "Routed: " + formatWithThousandSeparators(p.Amount) + "\nFee: " + formatWithThousandSeparators(p.Fee) + "\nPPM: " + formatWithThousandSeparators(p.PPM)
-			log.Println(p.R)
+		for i, p := range *chart {
+			(*chart)[i].R = 20 * p.Amount / maxAmount
+			(*chart)[i].Label = "Routed: " + formatWithThousandSeparators(p.Amount) + "\nFee: " + formatWithThousandSeparators(p.Fee) + "\nPPM: " + formatWithThousandSeparators(p.PPM)
 		}
 	}
 

--- a/cmd/psweb/ln/cln.go
+++ b/cmd/psweb/ln/cln.go
@@ -1104,17 +1104,18 @@ func HasInboundFees() bool {
 	return false
 }
 
-func ApplyAutoFeeAll() {
-	if !AutoFeeEnabledAll || autoFeeApplyAllIsRunning {
+func ApplyAutoFees() {
+	if !AutoFeeEnabledAll || autoFeeIsRunning {
 		return
 	}
 
-	autoFeeApplyAllIsRunning = true
+	autoFeeIsRunning = true
 
 	CacheForwards()
 
 	client, cleanup, err := GetClient()
 	if err != nil {
+		autoFeeIsRunning = false
 		return
 	}
 	defer cleanup()
@@ -1122,6 +1123,7 @@ func ApplyAutoFeeAll() {
 	var response map[string]interface{}
 
 	if client.Request(&ListPeerChannelsRequest{}, &response) != nil {
+		autoFeeIsRunning = false
 		return
 	}
 
@@ -1164,6 +1166,7 @@ func ApplyAutoFeeAll() {
 			} else {
 				// move threshold or do nothing
 				moveLowLiqThreshold(channelId, params.FailedMoveThreshold)
+				autoFeeIsRunning = false
 				return
 			}
 		}
@@ -1183,9 +1186,5 @@ func ApplyAutoFeeAll() {
 		}
 	}
 
-	autoFeeApplyAllIsRunning = false
-}
-
-func ApplyAutoFee() {
-	// not implemented
+	autoFeeIsRunning = false
 }

--- a/cmd/psweb/ln/common.go
+++ b/cmd/psweb/ln/common.go
@@ -122,6 +122,16 @@ type AutoFeeEvent struct {
 	IsManual  bool
 }
 
+// for chart plotting
+type DataPoint struct {
+	TS     uint64
+	Amount uint64
+	Fee    uint64
+	PPM    uint64
+	R      uint64
+	Label  string
+}
+
 var (
 	// lightning payments from swap out initiator to receiver
 	SwapRebates = make(map[string]int64)

--- a/cmd/psweb/ln/common.go
+++ b/cmd/psweb/ln/common.go
@@ -308,7 +308,7 @@ func LogAutoFee(channelId uint64, oldRate int, newRate int, isInbound bool) {
 		TimeStamp: time.Now().Unix(),
 		OldRate:   oldRate,
 		NewRate:   newRate,
-		IsInbound: true,
+		IsInbound: isInbound,
 	})
 	// persist to db
 	db.Save("AutoFees", "AutoFeeLog", AutoFeeLog)

--- a/cmd/psweb/ln/common.go
+++ b/cmd/psweb/ln/common.go
@@ -151,7 +151,7 @@ var (
 	lastForwardTS = make(map[uint64]int64)
 
 	// prevents starting another fee update while the first still running
-	autoFeeApplyAllIsRunning = false
+	autoFeeIsRunning = false
 )
 
 func toSats(amount float64) int64 {

--- a/cmd/psweb/ln/common.go
+++ b/cmd/psweb/ln/common.go
@@ -328,6 +328,8 @@ func moveLowLiqThreshold(channelId uint64, bump int) {
 	if AutoFee[channelId] == nil {
 		// add custom parameters
 		AutoFee[channelId] = new(AutoFeeParams)
+		// clone default values
+		*AutoFee[channelId] = AutoFeeDefaults
 	}
 
 	// do not alow exeeding high liquidity threshold

--- a/cmd/psweb/ln/common.go
+++ b/cmd/psweb/ln/common.go
@@ -143,7 +143,7 @@ var (
 		InactivityDays:    7,
 		InactivityDropPPM: 5,
 		InactivityDropPct: 5,
-		CoolOffHours:      12,
+		CoolOffHours:      24,
 		LowLiqDiscount:    0,
 	}
 

--- a/cmd/psweb/ln/common.go
+++ b/cmd/psweb/ln/common.go
@@ -75,14 +75,16 @@ type ChanneInfo struct {
 }
 
 type AutoFeeStatus struct {
-	Alias         string
-	ChannelId     uint64
-	LocalBalance  uint64
-	LocalPct      uint64
-	RemoteBalance uint64
-	Enabled       bool
-	Rates         string
-	Custom        bool
+	Alias       string
+	ChannelId   uint64
+	Capacity    uint64
+	LocalPct    uint64
+	Enabled     bool
+	Rule        string
+	AutoFee     *AutoFeeParams
+	Custom      bool
+	FeeRate     int64
+	InboundRate int64
 }
 
 type AutoFeeParams struct {
@@ -328,7 +330,11 @@ func moveLowLiqThreshold(channelId uint64, bump int) {
 		AutoFee[channelId] = new(AutoFeeParams)
 	}
 
-	AutoFee[channelId].LowLiqPct += bump
-	// persist to db
-	db.Save("AutoFees", "AutoFee", AutoFee)
+	// do not alow exeeding high liquidity threshold
+	if AutoFee[channelId].LowLiqPct+bump < AutoFee[channelId].ExcessPct {
+		AutoFee[channelId].LowLiqPct += bump
+		// persist to db
+		db.Save("AutoFees", "AutoFee", AutoFee)
+	}
+
 }

--- a/cmd/psweb/ln/lnd.go
+++ b/cmd/psweb/ln/lnd.go
@@ -1884,15 +1884,18 @@ func PlotPPM(channelId uint64) (*[]DataPoint, uint64) {
 	maxAmount := uint64(0)
 
 	for _, e := range forwardsOut[channelId] {
-		if maxAmount < e.AmtOut {
-			maxAmount = e.AmtOut
+		// ignore small forwards
+		if e.AmtOut > 1000 {
+			if maxAmount < e.AmtOut {
+				maxAmount = e.AmtOut
+			}
+			plot = append(plot, DataPoint{
+				TS:     e.TimestampNs / 1_000_000_000,
+				Amount: e.AmtOut,
+				Fee:    e.Fee,
+				PPM:    e.FeeMsat * 1_000_000 / e.AmtOutMsat,
+			})
 		}
-		plot = append(plot, DataPoint{
-			TS:     e.TimestampNs / 1_000_000_000,
-			Amount: e.AmtOut,
-			Fee:    e.Fee,
-			PPM:    e.FeeMsat * 1_000_000 / e.AmtOutMsat,
-		})
 	}
 
 	return &plot, maxAmount

--- a/cmd/psweb/ln/lnd.go
+++ b/cmd/psweb/ln/lnd.go
@@ -1878,3 +1878,22 @@ func ApplyAutoFees() {
 
 	autoFeeIsRunning = false
 }
+
+func PlotPPM(channelId uint64) (*[]DataPoint, uint64) {
+	var plot []DataPoint
+	maxAmount := uint64(0)
+
+	for _, e := range forwardsOut[channelId] {
+		if maxAmount < e.AmtOut {
+			maxAmount = e.AmtOut
+		}
+		plot = append(plot, DataPoint{
+			TS:     e.TimestampNs / 1_000_000_000,
+			Amount: e.AmtOut,
+			Fee:    e.Fee,
+			PPM:    e.FeeMsat * 1_000_000 / e.AmtOutMsat,
+		})
+	}
+
+	return &plot, maxAmount
+}

--- a/cmd/psweb/ln/lnd.go
+++ b/cmd/psweb/ln/lnd.go
@@ -1855,11 +1855,11 @@ func ApplyAutoFees() {
 			toSet := false
 			discountRate := int64(0)
 
-			if liqPct < params.LowLiqPct && policy.InboundFeeRateMilliMsat > int32(params.LowLiqDiscount) {
-				// set inbound fee discount if larger than current
+			if liqPct < params.LowLiqPct && policy.InboundFeeRateMilliMsat != int32(params.LowLiqDiscount) {
+				// set inbound fee discount
 				discountRate = int64(params.LowLiqDiscount)
 				toSet = true
-			} else if liqPct >= params.LowLiqPct {
+			} else if liqPct >= params.LowLiqPct && policy.InboundFeeRateMilliMsat < 0 {
 				// remove discount unless it was manually set
 				if !LastAutoFeeLog(ch.ChanId, true).IsManual {
 					toSet = true

--- a/cmd/psweb/ln/lnd.go
+++ b/cmd/psweb/ln/lnd.go
@@ -1879,16 +1879,12 @@ func ApplyAutoFees() {
 	autoFeeIsRunning = false
 }
 
-func PlotPPM(channelId uint64) (*[]DataPoint, uint64) {
+func PlotPPM(channelId uint64) *[]DataPoint {
 	var plot []DataPoint
-	maxAmount := uint64(0)
 
 	for _, e := range forwardsOut[channelId] {
 		// ignore small forwards
 		if e.AmtOut > 1000 {
-			if maxAmount < e.AmtOut {
-				maxAmount = e.AmtOut
-			}
 			plot = append(plot, DataPoint{
 				TS:     e.TimestampNs / 1_000_000_000,
 				Amount: e.AmtOut,
@@ -1898,5 +1894,5 @@ func PlotPPM(channelId uint64) (*[]DataPoint, uint64) {
 		}
 	}
 
-	return &plot, maxAmount
+	return &plot
 }

--- a/cmd/psweb/ln/lnd.go
+++ b/cmd/psweb/ln/lnd.go
@@ -1803,7 +1803,7 @@ func ApplyAutoFees() {
 	}
 
 	for _, ch := range res.Channels {
-		if ch.UnsettledBalance != 0 {
+		if ch.UnsettledBalance != 0 || !AutoFeeEnabled[ch.ChanId] {
 			// skip af while htlcs are pending
 			continue
 		}

--- a/cmd/psweb/ln/lnd.go
+++ b/cmd/psweb/ln/lnd.go
@@ -694,7 +694,7 @@ func GetMyAlias() string {
 	return myNodeAlias
 }
 
-func downloadInvoices(client lnrpc.LightningClient) {
+func downloadInvoices(client lnrpc.LightningClient) error {
 	// only go back 6 months for itinial download
 	start := uint64(time.Now().AddDate(0, -6, 0).Unix())
 	offset := uint64(0)
@@ -716,7 +716,7 @@ func downloadInvoices(client lnrpc.LightningClient) {
 			if !strings.HasPrefix(fmt.Sprint(err), "rpc error: code = Unknown desc = waiting to start") {
 				log.Println("ListInvoices:", err)
 			}
-			return
+			return err
 		}
 
 		for _, invoice := range res.Invoices {
@@ -743,6 +743,7 @@ func downloadInvoices(client lnrpc.LightningClient) {
 		log.Printf("Cached %d invoices", totalInvoices)
 	}
 
+	return nil
 }
 
 func downloadForwards(client lnrpc.LightningClient) {
@@ -1053,7 +1054,9 @@ func SubscribeAll() {
 	ctx := context.Background()
 
 	// initial download
-	downloadInvoices(client)
+	if downloadInvoices(client) != nil {
+		return
+	}
 
 	routerClient := routerrpc.NewRouterClient(conn)
 

--- a/cmd/psweb/ln/lnd.go
+++ b/cmd/psweb/ln/lnd.go
@@ -1050,8 +1050,7 @@ func SubscribeAll() {
 		downloadForwards(client)
 		// subscribe to Forwards
 		for {
-			if err := subscribeForwards(ctx, routerClient); err != nil {
-				log.Println("Forwards subscription error:", err)
+			if subscribeForwards(ctx, routerClient) != nil {
 				time.Sleep(60 * time.Second)
 			}
 		}
@@ -1063,8 +1062,7 @@ func SubscribeAll() {
 
 		// subscribe to Payments
 		for {
-			if err := subscribePayments(ctx, routerClient); err != nil {
-				log.Println("Payments subscription error:", err)
+			if subscribePayments(ctx, routerClient) != nil {
 				time.Sleep(60 * time.Second)
 			}
 		}
@@ -1074,8 +1072,7 @@ func SubscribeAll() {
 
 	// subscribe to Invoices
 	for {
-		if err := subscribeInvoices(ctx, client); err != nil {
-			log.Println("Invoices subscription error:", err)
+		if subscribeInvoices(ctx, client) != nil {
 			time.Sleep(60 * time.Second)
 		}
 	}

--- a/cmd/psweb/ln/lnd.go
+++ b/cmd/psweb/ln/lnd.go
@@ -1851,8 +1851,8 @@ func ApplyAutoFees() {
 			}
 		}
 
-		// set inbound fee
-		if HasInboundFees() && liqPct < params.LowLiqPct && policy.InboundFeeRateMilliMsat != int32(params.LowLiqDiscount) {
+		// set inbound fee discount if larger than current
+		if HasInboundFees() && liqPct < params.LowLiqPct && policy.InboundFeeRateMilliMsat > int32(params.LowLiqDiscount) {
 			// set discount
 			_, err := SetFeeRate(peerId, ch.ChanId, int64(params.LowLiqDiscount), true, false)
 			if err == nil {

--- a/cmd/psweb/main.go
+++ b/cmd/psweb/main.go
@@ -348,7 +348,7 @@ func onTimer() {
 	go ln.SubscribeAll()
 
 	// execute auto fee
-	go ln.ApplyAutoFeeAll()
+	go ln.ApplyAutoFees()
 }
 
 func liquidBackup(force bool) {

--- a/cmd/psweb/main.go
+++ b/cmd/psweb/main.go
@@ -34,7 +34,7 @@ import (
 
 const (
 	// App version tag
-	version = "v1.5.3"
+	version = "v1.5.4"
 )
 
 type SwapParams struct {

--- a/cmd/psweb/main.go
+++ b/cmd/psweb/main.go
@@ -133,6 +133,7 @@ func main() {
 			"fmt":  formatWithThousandSeparators,
 			"fs":   formatSigned,
 			"m":    toMil,
+			"last": last,
 		}).
 		ParseFS(tplFolder, templateNames...))
 
@@ -1495,4 +1496,9 @@ func feeInputField(peerNodeId string, channelId uint64, direction string, feePer
 	t += `</td>`
 
 	return t
+}
+
+// Template function to check if the element is the last one in the slice
+func last(x int, a interface{}) bool {
+	return x == len(*(a.(*[]ln.DataPoint)))-1
 }

--- a/cmd/psweb/templates/af.gohtml
+++ b/cmd/psweb/templates/af.gohtml
@@ -315,7 +315,7 @@
                   label: 'Realized Routing PPM',
                   data: [
                       {{range $index, $element := .Chart}}
-                        { x: new Date({{$element.TS}} * 1000), y: {{$element.PPM}}, r: {{$element.R}}, label: "{{$element.Label}}" }{{if not (last $index $.Chart)}},{{end}}
+                        { x: new Date({{$element.TS}} * 1000), y: {{$element.PPM}}, r: {{$element.R}}, label: `{{$element.Label | jsStr}}` }{{if not (last $index $.Chart)}},{{end}}
                       {{end}}
                   ],
                   backgroundColor: 'rgba(54, 162, 235, 0.8)',
@@ -357,8 +357,6 @@
                       callbacks: {
                           label: function(context) {
                               let label = context.raw.label || '';
-                              label += '<br>' + moment(context.raw.x).format('YYYY-MM-DD')
-                              label = label.replace(/\<br>/g, '\n'); // Replace '<br>' with actual line breaks
                               return label;
                           },
                       },
@@ -377,6 +375,14 @@
               }
           }
       });
+
+      // Custom function to handle JavaScript string escaping for Go templates
+      function jsStr(s) {
+          return s.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$/g, '\\$').replace(/\n/g, '\\n').replace(/\r/g, '\\r').replace(/\t/g, '\\t');
+      }
+
+      // Add custom function to the template context
+      {{define "jsStr"}}jsStr{{end}}
     </script>
     </div>
   {{template "footer" .}}

--- a/cmd/psweb/templates/af.gohtml
+++ b/cmd/psweb/templates/af.gohtml
@@ -240,10 +240,10 @@
               <thead>
                 <tr>
                   <th>Alias</th>
-                  <th title="Channel's capacity" style="width: 7ch; text-align: center;">Cap</th>
-                  <th title="Local balance as % of capacity" style="width: 3ch; text-align: center;">%</th>
-                  <th title="Outbound Fee Rate" style="width: 5ch; text-align: right;">Rate</th>
-                  <th title="Inbound Fee Rate" style="width: 3ch; text-align: right;">In</th>
+                  <th title="Channel's capacity" style="width: 7ch; text-align: right;">Cap</th>
+                  <th title="Local balance as % of capacity" style="width: 3ch; text-align: right;">%</th>
+                  <th title="Outbound Fee Rate" style="width: 6ch; text-align: right;">Rate</th>
+                  <th title="Inbound Fee Rate" style="width: 4ch; text-align: right;">In</th>
                   <th title="HighLiq/Normal/LowLiq{{if .HasInboundFees}}/Discount{{end}} PPM rates
 * indicates custom rule" style="text-align: center;">AF Rules</th>
                   <th style="width: 4ch; text-align: left; transform: scale(1.5)"><a title="Enable for all individual channels" href="javascript:void(0);" onclick="toggleAll(true)">☑</a></th>
@@ -253,8 +253,8 @@
               {{range .ChannelList}}
                 <tr{{if .Enabled}} class="is-selected"{{end}}>
                   <td class="truncate"><a href="/af?id={{.ChannelId}}">{{.Alias}}</a></td>
-                  <td style="text-align: center;">{{m .Capacity}}</td>
-                  <td style="text-align: center; {{if .Enabled}}
+                  <td style="text-align: right;">{{m .Capacity}}</td>
+                  <td style="text-align: right; {{if .Enabled}}
                     {{if gt .LocalPct .AutoFee.ExcessPct}}
                       color:lightgreen
                     {{end}}

--- a/cmd/psweb/templates/af.gohtml
+++ b/cmd/psweb/templates/af.gohtml
@@ -375,14 +375,6 @@
               }
           }
       });
-
-      // Custom function to handle JavaScript string escaping for Go templates
-      function jsStr(s) {
-          return s.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$/g, '\\$').replace(/\n/g, '\\n').replace(/\r/g, '\\r').replace(/\t/g, '\\t');
-      }
-
-      // Add custom function to the template context
-      {{define "jsStr"}}jsStr{{end}}
     </script>
     </div>
   {{template "footer" .}}

--- a/cmd/psweb/templates/af.gohtml
+++ b/cmd/psweb/templates/af.gohtml
@@ -127,12 +127,34 @@
                   </td>
                   <td>
                     <div class="field-label is-normal">
-                      <label title="Fee rate PPM increase after each 'Insufficient Balance' HTLC failure" class="label">Fail Bump</label>
+                      <label title="Inbound fee discount when liquidity is below Low Liq % (use negative value)" class="label">Low Liq Discount</label>
+                    </div>
+                  </td>
+                  <td>
+                    <div class="field-body">
+                      <input class="input is-medium" type="number" name="lowLiqDiscount" max="0" required value="{{.Params.LowLiqDiscount}}" {{if not .HasInboundFees}}disabled{{end}}>
+                    </div>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <div class="field-label is-normal">
+                      <label title="Fee rate PPM increase after each 'Insufficient Balance' HTLC failure below Low Liq threshold" class="label">Fail Bump</label>
                     </div>
                   </td>
                   <td>
                     <div class="field-body">
                       <input class="input is-medium" type="number" name="failBump" min="0" required value="{{.Params.FailedBumpPPM}}">
+                    </div>
+                  </td>
+                  <td>
+                    <div class="field-label is-normal">
+                      <label title="Move Low Liq % theshold higher after each 'Insufficient Balance' HTLC failure above it" class="label">Fail % Move</label>
+                    </div>
+                  </td>
+                  <td>
+                    <div class="field-body">
+                      <input class="input is-medium" type="number" name="failedMoveThreshold" min="0" required value="{{.Params.FailedMoveThreshold}}">
                     </div>
                   </td>
                 </tr>
@@ -180,20 +202,6 @@
                     </div>
                   </td>
                 </tr>
-                {{if .HasInboundFees}}
-                  <tr>
-                    <td>
-                      <div class="field-label is-normal">
-                        <label title="Inbound fee discount when liquidity is below Low Liq % (use negative value)" class="label">Low Liq Discount</label>
-                      </div>
-                    </td>
-                    <td>
-                      <div class="field-body">
-                        <input class="input is-medium" type="number" name="lowLiqDiscount" max="0" required value="{{.Params.LowLiqDiscount}}">
-                      </div>
-                    </td> 
-                  </tr>
-                {{end}}
               </table>
               <div style="text-align: center;">
                 <input type="hidden" name="action" value="saveAutoFee">

--- a/cmd/psweb/templates/af.gohtml
+++ b/cmd/psweb/templates/af.gohtml
@@ -211,8 +211,15 @@
                   <input class="button is-large" type="submit" name="delete_button" value="Delete Custom Rule">
                 {{end}}
               </div>
+            </form>
+          </div>
+          {{if ne .ChannelId 0}}
+            <div class="box has-text-left">
+              <div style="width: 100%; margin: auto;">
+                <canvas id="myScatterChart"></canvas>
+              </div>
             </div>
-          </form>
+          {{end}}
         </div> 
         <div class="column"> 
           <div class="box has-text-left">
@@ -259,7 +266,7 @@
                       color:lightgreen
                     {{end}}
                     {{if gt .AutoFee.LowLiqPct .LocalPct}}
-                      color:red
+                      color:pink
                     {{end}}{{end}}">{{fmt .LocalPct}}</td>
                   <td style="text-align: right;">{{fs .FeeRate}}</td>
                   <td style="text-align: right;">{{fs .InboundRate}}</td>
@@ -296,6 +303,77 @@
           }
         }
       }
+
+      // Get the context of the canvas element we want to select
+      var ctx = document.getElementById('myScatterChart').getContext('2d');
+
+      // Create the chart
+      var myScatterChart = new Chart(ctx, {
+          type: 'bubble', // The type of chart we want to create
+          data: {
+              datasets: [{
+                  label: 'Realized Routing PPM',
+                  data: [
+                      {{range $index, $element := .Chart}}
+                        { x: new Date({{$element.TS}} * 1000), y: {{$element.PPM}}, r: {{$element.R}}, label: "{{$element.Label}}" }{{if not (last $index $.Chart)}},{{end}}
+                      {{end}}
+                  ],
+                  backgroundColor: 'rgba(54, 162, 235, 0.8)',
+                  borderColor: 'rgba(75, 192, 192, 1)',
+                  borderWidth: 1
+              }]
+          },
+          options: {
+              scales: {
+                  x: {
+                      type: 'time',
+                      time: {
+                          unit: 'month'
+                      },
+                      position: 'bottom',
+                      ticks: {
+                          color: '{{if eq .ColorScheme "dark"}}white{{else}}black{{end}}'
+                      },
+                      title: {
+                          display: false,
+                          text: 'Date',
+                          color: '{{if eq .ColorScheme "dark"}}white{{else}}black{{end}}'
+                      }
+                  },
+                  y: {
+                      beginAtZero: false,
+                      ticks: {
+                          color: '{{if eq .ColorScheme "dark"}}white{{else}}black{{end}}'
+                      },
+                      title: {
+                          display: true,
+                          text: 'PPM',
+                          color: '{{if eq .ColorScheme "dark"}}white{{else}}black{{end}}'
+                      }
+                  }
+              },
+              plugins: {
+                  tooltip: {
+                      callbacks: {
+                          label: function(context) {
+                              let label = context.raw.label || '';
+                              return label;
+                          },
+                      },
+                      backgroundColor: 'rgba(0, 0, 0, 0.8)',
+                      titleColor: '{{if eq .ColorScheme "dark"}}white{{else}}black{{end}}',
+                      bodyColor: '{{if eq .ColorScheme "dark"}}white{{else}}black{{end}}',
+                      borderColor: '{{if eq .ColorScheme "dark"}}rgba(255, 255, 255, 0.8){{else}}rgba(0, 0, 0, 0.8){{end}}',
+                      borderWidth: 1,
+                  },
+                  legend: {
+                      labels: {
+                          color: '{{if eq .ColorScheme "dark"}}white{{else}}black{{end}}'
+                      }
+                  }
+              }
+          }
+      });
     </script>
     </div>
   {{template "footer" .}}

--- a/cmd/psweb/templates/af.gohtml
+++ b/cmd/psweb/templates/af.gohtml
@@ -240,12 +240,12 @@
               <thead>
                 <tr>
                   <th>Alias</th>
-                  <th title="Channel's capacity" style="width: 5ch; text-align: center;">Cap</th>
+                  <th title="Channel's capacity" style="width: 7ch; text-align: center;">Cap</th>
                   <th title="Local balance as % of capacity" style="width: 3ch; text-align: center;">%</th>
-                  <th title="Outbound Fee Rate" style="width: 5ch; text-align: center;">Rate</th>
+                  <th title="Outbound Fee Rate" style="width: 5ch; text-align: right;">Rate</th>
                   <th title="Inbound Fee Rate" style="width: 3ch; text-align: right;">In</th>
                   <th title="HighLiq/Normal/LowLiq{{if .HasInboundFees}}/Discount{{end}} PPM rates
-* indicates custom rule" style="text-align: center;">Rules</th>
+* indicates custom rule" style="text-align: center;">AF Rules</th>
                   <th style="width: 4ch; text-align: left; transform: scale(1.5)"><a title="Enable for all individual channels" href="javascript:void(0);" onclick="toggleAll(true)">☑</a></th>
                 </tr>
               </thead>
@@ -255,9 +255,9 @@
                   <td class="truncate"><a href="/af?id={{.ChannelId}}">{{.Alias}}</a></td>
                   <td style="text-align: center;">{{m .Capacity}}</td>
                   <td style="text-align: center;{{if gt .LocalPct .AutoFee.ExcessPct}} color:lightgreen{{end}}{{if gt .AutoFee.LowLiqPct .LocalPct}} color:red{{end}}">{{fmt .LocalPct}}</td>
-                  <td style="text-align: center;">{{fs .FeeRate}}</td>
+                  <td style="text-align: right;">{{fs .FeeRate}}</td>
                   <td style="text-align: right;">{{fs .InboundRate}}</td>
-                  <td class="truncate" style="text-align: center;">{{if .Custom}}*{{end}}{{.Rule}}</td>
+                  <td class="truncate" style="text-align: center;">{{if .Enabled}}{{if .Custom}}*{{end}}{{.Rule}}{{end}}</td>
                   <td>
                     <form id="individualForm_{{.ChannelId}}" action="/submit" method="post">
                       <input type="hidden" name="action" value="toggleAutoFee">

--- a/cmd/psweb/templates/af.gohtml
+++ b/cmd/psweb/templates/af.gohtml
@@ -360,12 +360,6 @@
                               return label;
                           },
                       },
-                      backgroundColor: 'rgba(0, 0, 0, 0.8)',
-                      titleColor: '{{if eq .ColorScheme "dark"}}white{{else}}black{{end}}',
-                      bodyColor: '{{if eq .ColorScheme "dark"}}white{{else}}black{{end}}',
-                      borderColor: '{{if eq .ColorScheme "dark"}}rgba(255, 255, 255, 0.8){{else}}rgba(0, 0, 0, 0.8){{end}}',
-                      borderWidth: 1,
-                      displayColors: false // Hide color indicators in tooltip
                   },
                   legend: {
                       labels: {

--- a/cmd/psweb/templates/af.gohtml
+++ b/cmd/psweb/templates/af.gohtml
@@ -358,6 +358,7 @@
                           label: function(context) {
                               let label = context.raw.label || '';
                               label += '<br>' + moment(context.raw.x).format('YYYY-MM-DD')
+                              label = label.replace(/\<br>/g, '\n'); // Replace '<br>' with actual line breaks
                               return label;
                           },
                       },

--- a/cmd/psweb/templates/af.gohtml
+++ b/cmd/psweb/templates/af.gohtml
@@ -240,9 +240,10 @@
               <thead>
                 <tr>
                   <th>Alias</th>
-                  <th style="width: 7ch; text-align: center;">Local</th>
+                  <th title="Channel's capacity" style="width: 5ch; text-align: center;">Cap</th>
                   <th title="Local balance as % of capacity" style="width: 3ch; text-align: center;">%</th>
-                  <th style="width: 7ch; text-align: center;">Remote</th>
+                  <th title="Outbound Fee Rate" style="width: 5ch; text-align: center;">Rate</th>
+                  <th title="Inbound Fee Rate" style="width: 3ch; text-align: right;">In</th>
                   <th title="HighLiq/Normal/LowLiq{{if .HasInboundFees}}/Discount{{end}} PPM rates
 * indicates custom rule" style="text-align: center;">Rules</th>
                   <th style="width: 4ch; text-align: left; transform: scale(1.5)"><a title="Enable for all individual channels" href="javascript:void(0);" onclick="toggleAll(true)">☑</a></th>
@@ -252,10 +253,11 @@
               {{range .ChannelList}}
                 <tr{{if .Enabled}} class="is-selected"{{end}}>
                   <td class="truncate"><a href="/af?id={{.ChannelId}}">{{.Alias}}</a></td>
-                  <td style="text-align: center;">{{m .LocalBalance}}</td>
-                  <td style="text-align: center;">{{fmt .LocalPct}}</td>
-                  <td style="text-align: center;">{{m .RemoteBalance}}</td>
-                  <td class="truncate" style="text-align: center;">{{if .Custom}}*{{end}}{{.Rates}}</td>
+                  <td style="text-align: center;">{{m .Capacity}}</td>
+                  <td style="text-align: center;{{if gt .LocalPct .AutoFee.ExcessPct}} color:lightgreen{{end}}{{if gt .AutoFee.LowLiqPct .LocalPct}} color:red{{end}}">{{fmt .LocalPct}}</td>
+                  <td style="text-align: center;">{{fs .FeeRate}}</td>
+                  <td style="text-align: right;">{{fs .InboundRate}}</td>
+                  <td class="truncate" style="text-align: center;">{{if .Custom}}*{{end}}{{.Rule}}</td>
                   <td>
                     <form id="individualForm_{{.ChannelId}}" action="/submit" method="post">
                       <input type="hidden" name="action" value="toggleAutoFee">

--- a/cmd/psweb/templates/af.gohtml
+++ b/cmd/psweb/templates/af.gohtml
@@ -357,6 +357,7 @@
                       callbacks: {
                           label: function(context) {
                               let label = context.raw.label || '';
+                              label += '<br>' + moment(context.raw.x).format('YYYY-MM-DD')
                               return label;
                           },
                       },

--- a/cmd/psweb/templates/af.gohtml
+++ b/cmd/psweb/templates/af.gohtml
@@ -215,6 +215,7 @@
           </div>
           {{if ne .ChannelId 0}}
             <div class="box has-text-left">
+            <h4 class="title is-4">Realized Routing PPM<h4>
               <div style="width: 100%; margin: auto;">
                 <canvas id="myScatterChart"></canvas>
               </div>
@@ -312,7 +313,6 @@
           type: 'bubble', // The type of chart we want to create
           data: {
               datasets: [{
-                  label: 'Realized Routing PPM',
                   data: [
                       {{range $index, $element := .Chart}}
                         { x: new Date({{$element.TS}} * 1000), y: {{$element.PPM}}, r: {{$element.R}}, label: `{{$element.Label}}` }{{if not (last $index $.Chart)}},{{end}}
@@ -346,7 +346,7 @@
                           color: '{{if eq .ColorScheme "dark"}}white{{else}}black{{end}}'
                       },
                       title: {
-                          display: true,
+                          display: false,
                           text: 'PPM',
                           color: '{{if eq .ColorScheme "dark"}}white{{else}}black{{end}}'
                       }
@@ -362,10 +362,8 @@
                       },
                   },
                   legend: {
-                      labels: {
-                          color: '{{if eq .ColorScheme "dark"}}white{{else}}black{{end}}'
-                      }
-                  }
+                      display: false
+                  },
               }
           }
       });

--- a/cmd/psweb/templates/af.gohtml
+++ b/cmd/psweb/templates/af.gohtml
@@ -375,6 +375,7 @@
               }
           }
       });
+
     </script>
     </div>
   {{template "footer" .}}

--- a/cmd/psweb/templates/af.gohtml
+++ b/cmd/psweb/templates/af.gohtml
@@ -366,6 +366,7 @@
                       bodyColor: '{{if eq .ColorScheme "dark"}}white{{else}}black{{end}}',
                       borderColor: '{{if eq .ColorScheme "dark"}}rgba(255, 255, 255, 0.8){{else}}rgba(0, 0, 0, 0.8){{end}}',
                       borderWidth: 1,
+                      displayColors: false // Hide color indicators in tooltip
                   },
                   legend: {
                       labels: {

--- a/cmd/psweb/templates/af.gohtml
+++ b/cmd/psweb/templates/af.gohtml
@@ -315,7 +315,7 @@
                   label: 'Realized Routing PPM',
                   data: [
                       {{range $index, $element := .Chart}}
-                        { x: new Date({{$element.TS}} * 1000), y: {{$element.PPM}}, r: {{$element.R}}, label: `{{$element.Label | jsStr}}` }{{if not (last $index $.Chart)}},{{end}}
+                        { x: new Date({{$element.TS}} * 1000), y: {{$element.PPM}}, r: {{$element.R}}, label: `{{$element.Label}}` }{{if not (last $index $.Chart)}},{{end}}
                       {{end}}
                   ],
                   backgroundColor: 'rgba(54, 162, 235, 0.8)',

--- a/cmd/psweb/templates/af.gohtml
+++ b/cmd/psweb/templates/af.gohtml
@@ -254,7 +254,13 @@
                 <tr{{if .Enabled}} class="is-selected"{{end}}>
                   <td class="truncate"><a href="/af?id={{.ChannelId}}">{{.Alias}}</a></td>
                   <td style="text-align: center;">{{m .Capacity}}</td>
-                  <td style="text-align: center;{{if gt .LocalPct .AutoFee.ExcessPct}} color:lightgreen{{end}}{{if gt .AutoFee.LowLiqPct .LocalPct}} color:red{{end}}">{{fmt .LocalPct}}</td>
+                  <td style="text-align: center; {{if .Enabled}}
+                    {{if gt .LocalPct .AutoFee.ExcessPct}}
+                      color:lightgreen
+                    {{end}}
+                    {{if gt .AutoFee.LowLiqPct .LocalPct}}
+                      color:red
+                    {{end}}{{end}}">{{fmt .LocalPct}}</td>
                   <td style="text-align: right;">{{fs .FeeRate}}</td>
                   <td style="text-align: right;">{{fs .InboundRate}}</td>
                   <td class="truncate" style="text-align: center;">{{if .Enabled}}{{if .Custom}}*{{end}}{{.Rule}}{{end}}</td>

--- a/cmd/psweb/templates/af.gohtml
+++ b/cmd/psweb/templates/af.gohtml
@@ -337,6 +337,9 @@
                             borderColor: 'rgba(255, 255, 255, 0.2)', // Set grid border color (white with slightly higher opacity)
                             borderWidth: 1 // Grid border width
                         },
+                        ticks: {
+                            color: 'white' // Set x-axis font color to white
+                        },
                       {{end}}
                       title: {
                           display: false,
@@ -349,6 +352,9 @@
                             color: 'rgba(255, 255, 255, 0.1)', // Set grid line color (white with reduced opacity)
                             borderColor: 'rgba(255, 255, 255, 0.2)', // Set grid border color (white with slightly higher opacity)
                             borderWidth: 1 // Grid border width
+                        },
+                        ticks: {
+                            color: 'white' // Set x-axis font color to white
                         },
                       {{end}}
                       title: {

--- a/cmd/psweb/templates/af.gohtml
+++ b/cmd/psweb/templates/af.gohtml
@@ -331,24 +331,28 @@
                           unit: 'month'
                       },
                       position: 'bottom',
-                      ticks: {
-                          color: '{{if eq .ColorScheme "dark"}}white{{else}}black{{end}}'
-                      },
+                      {{if eq .ColorScheme "dark"}}
+                        grid: {
+                            color: 'rgba(255, 255, 255, 0.1)', // Set grid line color (white with reduced opacity)
+                            borderColor: 'rgba(255, 255, 255, 0.2)', // Set grid border color (white with slightly higher opacity)
+                            borderWidth: 1 // Grid border width
+                        },
+                      {{end}}
                       title: {
                           display: false,
-                          text: 'Date',
-                          color: '{{if eq .ColorScheme "dark"}}white{{else}}black{{end}}'
                       }
                   },
                   y: {
                       beginAtZero: false,
-                      ticks: {
-                          color: '{{if eq .ColorScheme "dark"}}white{{else}}black{{end}}'
-                      },
+                      {{if eq .ColorScheme "dark"}}
+                        grid: {
+                            color: 'rgba(255, 255, 255, 0.1)', // Set grid line color (white with reduced opacity)
+                            borderColor: 'rgba(255, 255, 255, 0.2)', // Set grid border color (white with slightly higher opacity)
+                            borderWidth: 1 // Grid border width
+                        },
+                      {{end}}
                       title: {
                           display: false,
-                          text: 'PPM',
-                          color: '{{if eq .ColorScheme "dark"}}white{{else}}black{{end}}'
                       }
                   }
               },

--- a/cmd/psweb/templates/config.gohtml
+++ b/cmd/psweb/templates/config.gohtml
@@ -117,22 +117,39 @@
                     <div class="field-body">
                       <input class="input is-medium" type="text" value="{{.Config.ProxyURL}}" name="proxyURL" placeholder="socks5://127.0.0.1:9050">
                     </div>
-                  </div> 
-                  <div class="field is-horizontal">
-                    <div class="field-label is-normal">
-                      <label class="label">Color Theme</label>
-                    </div>
-                    <div class="field-body">
-                      <div class="select is-medium is-fullwidth">
-                        <select name="colorScheme">
-                          <option value="dark" {{if eq .Config.ColorScheme "dark"}}selected{{end}}>Dark</option>
-                          <option value="light" {{if eq .Config.ColorScheme "light"}}selected{{end}}>Light</option>
-                        </select>
+                  </div>
+                  {{if .IsPossibleHTTPS}}
+                    <div class="field is-horizontal">
+                      <div class="field-label is-normal">
+                        <label class="label">Color Theme</label>
+                      </div>
+                      <div class="field-body">
+                        <div class="select is-medium is-fullwidth">
+                          <select name="colorScheme">
+                            <option value="dark" {{if eq .Config.ColorScheme "dark"}}selected{{end}}>Dark</option>
+                            <option value="light" {{if eq .Config.ColorScheme "light"}}selected{{end}}>Light</option>
+                          </select>
+                        </div>
                       </div>
                     </div>
-                  </div>
+                  {{end}}
                 </div>
                 <div class="column has-text-left" style="padding-left:.75rem; padding-right:.75rem"> 
+                  {{if not .IsPossibleHTTPS}}
+                    <div class="field is-horizontal">
+                      <div class="field-label is-normal">
+                        <label class="label">Color Theme</label>
+                      </div>
+                      <div class="field-body">
+                        <div class="select is-medium is-fullwidth">
+                          <select name="colorScheme">
+                            <option value="dark" {{if eq .Config.ColorScheme "dark"}}selected{{end}}>Dark</option>
+                            <option value="light" {{if eq .Config.ColorScheme "light"}}selected{{end}}>Light</option>
+                          </select>
+                        </div>
+                      </div>
+                    </div>
+                  {{end}}
                   <div class="field is-horizontal">
                     <div class="field-label is-normal">
                       <label class="label">
@@ -203,27 +220,29 @@
                       <input class="input is-medium" type="password" value="{{.Config.BitcoinPass}}" name="bitcoinPass" placeholder="Bitcoin Core RPC Password">
                     </div>
                   </div>
-                  <div class="field is-horizontal">
-                    <div class="field-label is-normal">
-                      <label title="Enable TLS connection at {{.HTTPS}}" class="label">HTTPS **</label>
-                    </div>
-                    <div class="field-body">
-                      <div class="select is-medium is-fullwidth">
-                        <select id="secureConnection" name="secureConnection"{{if not .IsPossibleHTTPS}} disabled{{end}}>
-                          <option id="secureConnectionTrue" value="true" {{if .Config.SecureConnection}}selected{{end}}>Enable</option>
-                          <option id="secureConnectionFalse" value="false" {{if not .Config.SecureConnection}}selected{{end}}>Disable</option>
-                        </select>
+                  {{if .IsPossibleHTTPS}}
+                    <div class="field is-horizontal">
+                      <div class="field-label is-normal">
+                        <label title="Enable TLS connection at {{.HTTPS}}" class="label">HTTPS **</label>
+                      </div>
+                      <div class="field-body">
+                        <div class="select is-medium is-fullwidth">
+                          <select id="secureConnection" name="secureConnection">
+                            <option id="secureConnectionTrue" value="true" {{if .Config.SecureConnection}}selected{{end}}>Enable</option>
+                            <option id="secureConnectionFalse" value="false" {{if not .Config.SecureConnection}}selected{{end}}>Disable</option>
+                          </select>
+                        </div>
                       </div>
                     </div>
-                  </div>
-                  <div class="field is-horizontal">
-                    <div class="field-label is-normal">
-                      <label title="Space separated additional IP addresses for PeerSwap Web UI server certificate (LAN, Tailscale, etc)" class="label">PSWeb IPs **</label>
+                    <div class="field is-horizontal">
+                      <div class="field-label is-normal">
+                        <label title="Space separated additional IP addresses for PeerSwap Web UI server certificate (LAN, Tailscale, etc)" class="label">PSWeb IPs **</label>
+                      </div>
+                      <div class="field-body">
+                        <input class="input is-medium" type="text" value="{{.Config.ServerIPs}}" name="serverIPs" placeholder="192.168.1.123 100.123.123.1">
+                      </div>
                     </div>
-                    <div class="field-body">
-                      <input class="input is-medium" type="text" value="{{.Config.ServerIPs}}" name="serverIPs" placeholder="192.168.1.123 100.123.123.1"{{if not .IsPossibleHTTPS}} disabled{{end}}>
-                    </div>
-                  </div>
+                  {{end}}
                 </div>
               </div>
               <center>

--- a/cmd/psweb/templates/reusable.gohtml
+++ b/cmd/psweb/templates/reusable.gohtml
@@ -122,7 +122,7 @@
                     <td style="width: 100px;">
                         <div class="content has-text-centered">
                             <p>
-                                <strong>PeerSwap Web UI</strong> by <a href="https://github.com/Impa10r/peerswap-web" target="_blank">Vlad Goryachev</a>
+                                <strong>PeerSwap Web UI</strong> by <a href="https://github.com/Impa10r/peerswap-web" target="_blank">Impa10r</a>
                             </p>
                         </div>
                     </td>

--- a/cmd/psweb/templates/reusable.gohtml
+++ b/cmd/psweb/templates/reusable.gohtml
@@ -94,6 +94,10 @@
                     }
                 }
             </script>  
+            <script src="https://cdn.jsdelivr.net/npm/moment@2.29.1/moment.min.js"></script>
+            <script src="https://cdn.jsdelivr.net/npm/chart.js@3.7.1"></script>
+            <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-moment@1.0.0"></script>
+        </head>
         </header>
         <section class="section">
             {{if eq .ErrorMessage "welcome"}}


### PR DESCRIPTION
- Hide HTTPS option for Umbrel
- AF: apply HTLC Fail Bumps only when Local % <= Low Liq % 
- AF: for HTLC Fails above Low Liq % allow increasing Low Liq % threshold
- AF: log full fee changes history, including inbound
- AF: reduce LND load when applying auto fees
- AF: add realized PPM chart for the channel to help decide AF parameters