### PR TITLE
v1.6.7

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,7 @@
             "program": "${workspaceFolder}/cmd/psweb/",
             "showLog": false,
             "envFile": "${workspaceFolder}/.env",
-            // "args": ["-datadir", "/home/vlad/.peerswap2"]
+            "args": ["-datadir", "/home/vlad/.peerswap2"]
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,7 @@
             "program": "${workspaceFolder}/cmd/psweb/",
             "showLog": false,
             "envFile": "${workspaceFolder}/.env",
-            "args": ["-datadir", "/home/vlad/.peerswap2"]
+            //"args": ["-datadir", "/home/vlad/.peerswap2"]
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "type": "go",
             "request": "launch",
             "mode": "auto",
-            "buildFlags": "-tags cln",
+            "buildFlags": "-tags lnd",
             "program": "${workspaceFolder}/cmd/psweb/",
             "showLog": false,
             "envFile": "${workspaceFolder}/.env",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,7 @@
             "program": "${workspaceFolder}/cmd/psweb/",
             "showLog": false,
             "envFile": "${workspaceFolder}/.env",
-            //"args": ["-datadir", "/home/vlad/.peerswap2"]
+            "args": ["-datadir", "/home/vlad/.peerswap2"]
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,11 +9,11 @@
             "type": "go",
             "request": "launch",
             "mode": "auto",
-            "buildFlags": "-tags lnd",
+            "buildFlags": "-tags cln",
             "program": "${workspaceFolder}/cmd/psweb/",
             "showLog": false,
             "envFile": "${workspaceFolder}/.env",
-            "args": ["-datadir", "/home/vlad/.peerswap2"]
+            // "args": ["-datadir", "/home/vlad/.peerswap2"]
         }
     ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Pre-fill 0 if recommended swap amount is below 100,000
 - Limit max swap out amount to peer's balance less 21,300 to avoid high fee
 - Limit max swap in amount to own balance less reserve to avoid high fee
+- Fix AutoFees stop working bug
 
 ## 1.6.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Limit max swap out amount to peer's balance less 21,300 to avoid high fee
 - Limit max swap in amount to own balance less reserve to avoid high fee
 - Fix AutoFees stop working bug
+- Highlight outputs to be used for peg-in or BTC withdrawal
 
 ## 1.6.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 ## 1.6.7
 
-- Pre-fill 0 if recommended swap amount is below 100,000
-- Limit max swap out amount to peer's balance less 21,300 to avoid high fee
-- Limit max swap in amount to own balance less reserve to avoid high fee
 - Fix AutoFees stop working bug
 - Fix AutoFees applied on startup before forwards history was downloaded
 - Highlight outputs to be used for peg-in or BTC withdrawal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Limit max swap out amount to peer's balance less 21,300 to avoid high fee
 - Limit max swap in amount to own balance less reserve to avoid high fee
 - Fix AutoFees stop working bug
+- Fix AutoFees applied on startup before forwards history was downloaded
 - Highlight outputs to be used for peg-in or BTC withdrawal
 
 ## 1.6.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.6.7
 
 - Pre-fill 0 if recommended swap amount is below 100,000
-- Set max swap out amount to peer's balance less 21,300 to avoid high fee
+- Limit max swap out amount to peer's balance less 21,300 to avoid high fee
 
 ## 1.6.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Pre-fill 0 if recommended swap amount is below 100,000
 - Limit max swap out amount to peer's balance less 21,300 to avoid high fee
+- Limit max swap in amount to own balance less reserve to avoid high fee
 
 ## 1.6.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Versions
 
+## 1.6.7
+
+- 
+
 ## 1.6.6
 
 - Allow advertising BTC balance to peers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.6.7
 
-- 
+- Pre-fill 0 if recommended swap amount is below 100,000
 
 ## 1.6.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@
 ## 1.6.7
 
 - Fix AutoFees stop working bug
-- Fix AutoFees applied on startup before forwards history was downloaded
+- Fix AutoFees applied on startup before forwards history has been downloaded
+- LND: Fix AutoFees reacting to temporary balance increase due to pendinng HTLCs
 - Highlight outputs to be used for peg-in or BTC withdrawal
-- Calculate max swap in and swap out amount
 - Warn when BTC swap-in amount is unlikely to cover chain fee 
+- Limit L-BTC swap-in amount to avoid excessive fee rate
 
 ## 1.6.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.6.7
 
 - Pre-fill 0 if recommended swap amount is below 100,000
+- Set max swap out amount to peer's balance less 21,300 to avoid high fee
 
 ## 1.6.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Fix AutoFees stop working bug
 - Fix AutoFees applied on startup before forwards history was downloaded
 - Highlight outputs to be used for peg-in or BTC withdrawal
+- Calculate max swap in and swap out amount
+- Warn when BTC swap-in amount is unlikely to cover chain fee 
 
 ## 1.6.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Fix AutoFees stop working bug
 - Fix AutoFees applied on startup before forwards history has been downloaded
-- LND: Fix AutoFees reacting to temporary balance increase due to pendinng HTLCs
+- LND 0.18: Fix AutoFees reacting to temporary balance increase due to pendinng HTLCs
 - Highlight outputs to be used for peg-in or BTC withdrawal
 - Warn when BTC swap-in amount is unlikely to cover chain fee 
 - Limit L-BTC swap-in amount to avoid excessive fee rate

--- a/cmd/psweb/handlers.go
+++ b/cmd/psweb/handlers.go
@@ -430,7 +430,8 @@ func peerHandler(w http.ResponseWriter, r *http.Request) {
 		// reserves are hardcoded here:
 		// https://github.com/ElementsProject/peerswap/blob/c77a82913d7898d0d3b7c83e4a990abf54bd97e5/swap/actions.go#L388
 		// https://github.com/ElementsProject/peerswap/blob/c77a82913d7898d0d3b7c83e4a990abf54bd97e5/peerswaprpc/server.go#L105
-		maxLiquidSwapOut = uint64(max(0, min(int64(maxLocalBalance)-5000, peerLiquidBalance-20300)))
+		// reduce balance by extra 1000 sats to avoid huge fee rate
+		maxLiquidSwapOut = uint64(max(0, min(int64(maxLocalBalance)-5000, peerLiquidBalance-20300-1000)))
 		if maxLiquidSwapOut >= 100_000 {
 			selectedChannel = peer.Channels[maxLocalBalanceIndex].ChannelId
 		} else {
@@ -442,7 +443,7 @@ func peerHandler(w http.ResponseWriter, r *http.Request) {
 	maxBitcoinSwapOut := uint64(0)
 	if ptr := ln.BitcoinBalances[peer.NodeId]; ptr != nil {
 		peerBitcoinBalance = int64(ptr.Amount)
-		maxBitcoinSwapOut = uint64(max(0, min(int64(maxLocalBalance)-5000, peerBitcoinBalance-20300)))
+		maxBitcoinSwapOut = uint64(max(0, min(int64(maxLocalBalance)-5000, peerBitcoinBalance-21300)))
 		if maxBitcoinSwapOut >= 100_000 {
 			selectedChannel = peer.Channels[maxLocalBalanceIndex].ChannelId
 		} else {
@@ -484,8 +485,8 @@ func peerHandler(w http.ResponseWriter, r *http.Request) {
 		recommendBitcoinSwapIn = min(maxBitcoinSwapIn, int64(maxRemoteBalance-channelCapacity/2))
 	}
 
-	if recommendBitcoinSwapIn < 100_000 {
-		recommendBitcoinSwapIn = 0
+	if recommendLiquidSwapIn < 100_000 {
+		recommendLiquidSwapIn = 0
 	}
 
 	if recommendBitcoinSwapIn < 100_000 {

--- a/cmd/psweb/handlers.go
+++ b/cmd/psweb/handlers.go
@@ -447,7 +447,7 @@ func peerHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// arbitrary haircut to avoid 'no matching outgoing channel available'
+	// arbitrary haircuts to avoid 'no matching outgoing channel available'
 	maxBitcoinSwapIn := min(btcBalance-2000, int64(maxRemoteBalance)-10000)
 	if maxBitcoinSwapIn < 100_000 {
 		maxBitcoinSwapIn = 0
@@ -465,11 +465,19 @@ func peerHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if recommendLiquidSwapOut < 100_000 {
-		recommendLiquidSwapOut = 0
+		if maxLiquidSwapOut >= 100_000 {
+			recommendLiquidSwapOut = 100_000
+		} else {
+			recommendLiquidSwapOut = 0
+		}
 	}
 
 	if recommendBitcoinSwapOut < 100_000 {
-		recommendBitcoinSwapOut = 0
+		if maxBitcoinSwapOut >= 100_000 {
+			recommendBitcoinSwapOut = 100_000
+		} else {
+			recommendBitcoinSwapOut = 0
+		}
 	}
 
 	// assume return to 50/50 channel
@@ -482,11 +490,19 @@ func peerHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if recommendLiquidSwapIn < 100_000 {
-		recommendLiquidSwapIn = 0
+		if maxLiquidSwapIn >= 100_000 {
+			recommendLiquidSwapIn = 100_000
+		} else {
+			recommendLiquidSwapIn = 0
+		}
 	}
 
 	if recommendBitcoinSwapIn < 100_000 {
-		recommendBitcoinSwapIn = 0
+		if maxBitcoinSwapIn >= 100_000 {
+			recommendBitcoinSwapIn = 100_000
+		} else {
+			recommendBitcoinSwapIn = 0
+		}
 	}
 
 	type Page struct {

--- a/cmd/psweb/handlers.go
+++ b/cmd/psweb/handlers.go
@@ -460,20 +460,36 @@ func peerHandler(w http.ResponseWriter, r *http.Request) {
 	directionIn := false
 
 	// assume return to 50/50 channel
-	recommendLiquidSwapOut := maxLiquidSwapOut
-	recommendBitcoinSwapOut := maxBitcoinSwapOut
+	recommendLiquidSwapOut := uint64(0)
+	recommendBitcoinSwapOut := uint64(0)
 	if maxLocalBalance > channelCapacity/2 {
 		recommendLiquidSwapOut = min(maxLiquidSwapOut, maxLocalBalance-channelCapacity/2)
-		recommendBitcoinSwapOut = min(recommendBitcoinSwapOut, maxLocalBalance-channelCapacity/2)
+		recommendBitcoinSwapOut = min(maxBitcoinSwapOut, maxLocalBalance-channelCapacity/2)
+	}
+
+	if recommendLiquidSwapOut < 100_000 {
+		recommendLiquidSwapOut = 0
+	}
+
+	if recommendBitcoinSwapOut < 100_000 {
+		recommendBitcoinSwapOut = 0
 	}
 
 	// assume return to 50/50 channel
-	recommendLiquidSwapIn := maxLiquidSwapIn
-	recommendBitcoinSwapIn := maxBitcoinSwapIn
+	recommendLiquidSwapIn := int64(0)
+	recommendBitcoinSwapIn := int64(0)
 	if maxRemoteBalance > channelCapacity/2 {
 		directionIn = true
-		recommendLiquidSwapIn = min(recommendLiquidSwapIn, int64(maxRemoteBalance-channelCapacity/2))
-		recommendBitcoinSwapIn = min(recommendBitcoinSwapIn, int64(maxRemoteBalance-channelCapacity/2))
+		recommendLiquidSwapIn = min(maxLiquidSwapIn, int64(maxRemoteBalance-channelCapacity/2))
+		recommendBitcoinSwapIn = min(maxBitcoinSwapIn, int64(maxRemoteBalance-channelCapacity/2))
+	}
+
+	if recommendBitcoinSwapIn < 100_000 {
+		recommendBitcoinSwapIn = 0
+	}
+
+	if recommendBitcoinSwapIn < 100_000 {
+		recommendBitcoinSwapIn = 0
 	}
 
 	type Page struct {

--- a/cmd/psweb/handlers.go
+++ b/cmd/psweb/handlers.go
@@ -417,7 +417,7 @@ func peerHandler(w http.ResponseWriter, r *http.Request) {
 	bitcoinFeeRate := max(ln.EstimateFee(), mempoolFeeRate)
 
 	// arbitrary haircut to avoid 'no matching outgoing channel available'
-	maxLiquidSwapIn := min(int64(satAmount)-2000, int64(maxRemoteBalance)-10000)
+	maxLiquidSwapIn := min(int64(satAmount)-int64(ln.SwapFeeReserveLBTC), int64(maxRemoteBalance)-10000)
 	if maxLiquidSwapIn < 100_000 {
 		maxLiquidSwapIn = 0
 	}
@@ -448,7 +448,7 @@ func peerHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// arbitrary haircuts to avoid 'no matching outgoing channel available'
-	maxBitcoinSwapIn := min(btcBalance-2000, int64(maxRemoteBalance)-10000)
+	maxBitcoinSwapIn := min(btcBalance-int64(ln.SwapFeeReserveBTC), int64(maxRemoteBalance)-10000)
 	if maxBitcoinSwapIn < 100_000 {
 		maxBitcoinSwapIn = 0
 	}

--- a/cmd/psweb/ln/cln.go
+++ b/cmd/psweb/ln/cln.go
@@ -1134,17 +1134,14 @@ func HasInboundFees() bool {
 }
 
 func ApplyAutoFees() {
-	if !AutoFeeEnabledAll || autoFeeIsRunning {
+	if !AutoFeeEnabledAll {
 		return
 	}
-
-	autoFeeIsRunning = true
 
 	CacheForwards()
 
 	client, cleanup, err := GetClient()
 	if err != nil {
-		autoFeeIsRunning = false
 		return
 	}
 	defer cleanup()
@@ -1152,7 +1149,6 @@ func ApplyAutoFees() {
 	var response map[string]interface{}
 
 	if client.Request(&ListPeerChannelsRequest{}, &response) != nil {
-		autoFeeIsRunning = false
 		return
 	}
 
@@ -1195,7 +1191,6 @@ func ApplyAutoFees() {
 			} else {
 				// move threshold or do nothing
 				moveLowLiqThreshold(channelId, params.FailedMoveThreshold)
-				autoFeeIsRunning = false
 				return
 			}
 		}
@@ -1214,8 +1209,6 @@ func ApplyAutoFees() {
 			}
 		}
 	}
-
-	autoFeeIsRunning = false
 }
 
 func PlotPPM(channelId uint64) *[]DataPoint {

--- a/cmd/psweb/ln/cln.go
+++ b/cmd/psweb/ln/cln.go
@@ -28,9 +28,9 @@ import (
 const (
 	Implementation = "CLN"
 	fileRPC        = "lightning-rpc"
-	// Liquid balance to reserve in auto swap-ins
 	// https://github.com/ElementsProject/peerswap/blob/master/clightning/clightning_commands.go#L392
-	SwapFeeReserveLBTC = uint64(0)
+	// 2000 to avoid high fee
+	SwapFeeReserveLBTC = uint64(2000)
 	SwapFeeReserveBTC  = uint64(2000)
 )
 

--- a/cmd/psweb/ln/cln.go
+++ b/cmd/psweb/ln/cln.go
@@ -30,8 +30,9 @@ const (
 	fileRPC        = "lightning-rpc"
 	// Liquid balance to reserve in auto swap-ins
 	// https://github.com/ElementsProject/peerswap/blob/master/clightning/clightning_commands.go#L392
-	SwapFeeReserveLBTC = uint64(0)
-	SwapFeeReserveBTC  = uint64(2000)
+	// extra 1000 reserve to avoid no-change tx spending all on fees
+	SwapFeeReserveLBTC = uint64(1000)
+	SwapFeeReserveBTC  = uint64(3000)
 )
 
 type Forwarding struct {

--- a/cmd/psweb/ln/cln.go
+++ b/cmd/psweb/ln/cln.go
@@ -30,9 +30,8 @@ const (
 	fileRPC        = "lightning-rpc"
 	// Liquid balance to reserve in auto swap-ins
 	// https://github.com/ElementsProject/peerswap/blob/master/clightning/clightning_commands.go#L392
-	// extra 1000 reserve to avoid no-change tx spending all on fees
-	SwapFeeReserveLBTC = uint64(1000)
-	SwapFeeReserveBTC  = uint64(3000)
+	SwapFeeReserveLBTC = uint64(0)
+	SwapFeeReserveBTC  = uint64(2000)
 )
 
 type Forwarding struct {

--- a/cmd/psweb/ln/common.go
+++ b/cmd/psweb/ln/common.go
@@ -193,9 +193,6 @@ var (
 	// track timestamp of the last outbound forward per channel
 	LastForwardTS = make(map[uint64]int64)
 
-	// prevents starting another fee update while the first still running
-	autoFeeIsRunning = false
-
 	// received via custom messages, per peer nodeId
 	LiquidBalances  = make(map[string]*BalanceInfo)
 	BitcoinBalances = make(map[string]*BalanceInfo)

--- a/cmd/psweb/ln/lnd.go
+++ b/cmd/psweb/ln/lnd.go
@@ -45,8 +45,9 @@ const (
 	Implementation = "LND"
 	// Liquid balance to reserve in auto swap-ins
 	// https://github.com/ElementsProject/peerswap/blob/master/peerswaprpc/server.go#L234
-	SwapFeeReserveLBTC = uint64(1000)
-	SwapFeeReserveBTC  = uint64(2000)
+	// extra 1000 reserve to avoid no-change tx spending all on fees
+	SwapFeeReserveLBTC = uint64(2000)
+	SwapFeeReserveBTC  = uint64(3000)
 )
 
 type InflightHTLC struct {

--- a/cmd/psweb/ln/lnd.go
+++ b/cmd/psweb/ln/lnd.go
@@ -1968,9 +1968,6 @@ func ApplyAutoFees() {
 			if err == nil {
 				// log the last change
 				LogFee(ch.ChanId, oldFee, newFee, false, false)
-
-				log.Println(ch, liqPct, oldFee, newFee)
-
 			}
 		}
 

--- a/cmd/psweb/ln/lnd.go
+++ b/cmd/psweb/ln/lnd.go
@@ -45,9 +45,8 @@ const (
 	Implementation = "LND"
 	// Liquid balance to reserve in auto swap-ins
 	// https://github.com/ElementsProject/peerswap/blob/master/peerswaprpc/server.go#L234
-	// extra 1000 reserve to avoid no-change tx spending all on fees
-	SwapFeeReserveLBTC = uint64(2000)
-	SwapFeeReserveBTC  = uint64(3000)
+	SwapFeeReserveLBTC = uint64(1000)
+	SwapFeeReserveBTC  = uint64(2000)
 )
 
 type InflightHTLC struct {

--- a/cmd/psweb/main.go
+++ b/cmd/psweb/main.go
@@ -36,6 +36,13 @@ import (
 const (
 	// App version tag
 	version = "v1.6.7"
+
+	// Swap Out reserves are hardcoded here:
+	// https://github.com/ElementsProject/peerswap/blob/c77a82913d7898d0d3b7c83e4a990abf54bd97e5/peerswaprpc/server.go#L105
+	swapOutChannelReserve = 5000
+	// https://github.com/ElementsProject/peerswap/blob/c77a82913d7898d0d3b7c83e4a990abf54bd97e5/swap/actions.go#L388
+	// increaased by extra 1000 sats to avoid huge fee rate
+	swapOutChainReserve = 21300
 )
 
 type SwapParams struct {

--- a/cmd/psweb/main.go
+++ b/cmd/psweb/main.go
@@ -41,7 +41,7 @@ const (
 	// https://github.com/ElementsProject/peerswap/blob/c77a82913d7898d0d3b7c83e4a990abf54bd97e5/peerswaprpc/server.go#L105
 	swapOutChannelReserve = 5000
 	// https://github.com/ElementsProject/peerswap/blob/c77a82913d7898d0d3b7c83e4a990abf54bd97e5/swap/actions.go#L388
-	// increaased by extra 1000 sats to avoid huge fee rate
+	// increased by extra 1000 sats to avoid huge fee rate
 	swapOutChainReserve = 21300
 )
 
@@ -1392,8 +1392,7 @@ func executeAutoSwap() {
 		return
 	}
 
-	// extra 1000 reserve to avoid no-change tx spending all on fees
-	amount = min(amount, satAmount-ln.SwapFeeReserveLBTC-1000)
+	amount = min(amount, satAmount-ln.SwapFeeReserveLBTC)
 
 	// execute swap
 	id, err := ps.SwapIn(client, amount, candidate.ChannelId, "lbtc", false)

--- a/cmd/psweb/main.go
+++ b/cmd/psweb/main.go
@@ -328,16 +328,16 @@ func redirectWithError(w http.ResponseWriter, r *http.Request, redirectUrl strin
 
 func startTimer() {
 	// first run immediately
-	onTimer()
+	onTimer(true)
 
 	// then every minute
 	for range time.Tick(60 * time.Second) {
-		onTimer()
+		onTimer(false)
 	}
 }
 
 // tasks that run every minute
-func onTimer() {
+func onTimer(firstRun bool) {
 	// Start Telegram bot if not already running
 	go telegramStart()
 
@@ -373,7 +373,10 @@ func onTimer() {
 	go ln.SubscribeAll()
 
 	// execute auto fee
-	go ln.ApplyAutoFees()
+	if !firstRun {
+		// skip first run so that forwards have time to download
+		go ln.ApplyAutoFees()
+	}
 
 	// advertise Liquid balance
 	go advertiseBalances()

--- a/cmd/psweb/main.go
+++ b/cmd/psweb/main.go
@@ -43,6 +43,7 @@ const (
 	// https://github.com/ElementsProject/peerswap/blob/c77a82913d7898d0d3b7c83e4a990abf54bd97e5/swap/actions.go#L388
 	// increased by extra 1000 sats to avoid huge fee rate
 	swapOutChainReserve = 21300
+	// for Swap In reserves see /ln
 )
 
 type SwapParams struct {
@@ -649,7 +650,11 @@ func convertPeersToHTMLTable(
 		peerTable += "<td class=\"truncate\" id=\"scramble\" style=\"padding: 0px; padding-left: 1px; float: left; text-align: left; width: 70%;\">"
 
 		// alias is a link to open peer details page
-		peerTable += "<a href=\"/peer?id=" + peer.NodeId + "\">"
+		if len(peer.Channels) > 0 {
+			peerTable += "<a href=\"/peer?id=" + peer.NodeId + "\">"
+		} else {
+			peerTable += "<a href=\"" + config.Config.NodeApi + "/" + peer.NodeId + "\" target=\"_blank\">"
+		}
 
 		if stringIsInSlice(peer.NodeId, allowlistedPeers) {
 			peerTable += "<span title=\"Peer is whitelisted\">✅&nbsp</span>"

--- a/cmd/psweb/main.go
+++ b/cmd/psweb/main.go
@@ -42,7 +42,7 @@ const (
 	swapOutChannelReserve = 5000
 	// https://github.com/ElementsProject/peerswap/blob/c77a82913d7898d0d3b7c83e4a990abf54bd97e5/swap/actions.go#L388
 	// increased by extra 1000 sats to avoid huge fee rate
-	swapOutChainReserve = 21300
+	swapOutChainReserve = 20300
 	// for Swap In reserves see /ln
 )
 

--- a/cmd/psweb/main.go
+++ b/cmd/psweb/main.go
@@ -1673,7 +1673,7 @@ func advertiseBalances() {
 
 	for _, peer := range res3.GetPeers() {
 		if ln.Implementation == "LND" {
-			// refresh balances received over 24 hours ago + 2 minutes
+			// refresh balances received over 24 hours ago + 2 minutes ago
 			pollPeer := false
 			if ptr := ln.LiquidBalances[peer.NodeId]; ptr != nil {
 				if ptr.TimeStamp < cutOff {

--- a/cmd/psweb/main.go
+++ b/cmd/psweb/main.go
@@ -35,7 +35,7 @@ import (
 
 const (
 	// App version tag
-	version = "v1.6.6"
+	version = "v1.6.7"
 )
 
 type SwapParams struct {

--- a/cmd/psweb/templates/bitcoin.gohtml
+++ b/cmd/psweb/templates/bitcoin.gohtml
@@ -235,7 +235,7 @@
                   <th style="width: 9ch; text-align: right;">Confs</th>
                   <th style="width: 10ch; text-align: right;">Amount</th>
                   {{if eq .PeginTxId ""}}
-                    <th style="width: 2ch; transform: scale(1.5)"><a title="Select all" href="javascript:void(0);" onclick="setMax()">☑</a></th>
+                    <th style="width: 4ch; transform: scale(1.5)"><a title="Select all" href="javascript:void(0);" onclick="setMax()">☑</a></th>
                   {{end}}
                 </tr>
               </thead>

--- a/cmd/psweb/templates/bitcoin.gohtml
+++ b/cmd/psweb/templates/bitcoin.gohtml
@@ -38,7 +38,7 @@
               <div class="tabs is-large is-boxed">
                 <ul>
                   <li title="The process will require 102 confirmations. Transaction fee rate can be bumped with {{if .CanRBF}}RBF{{else}}CPFP{{end}}." id="peginTab" class="is-active"><a href="javascript:void(0);" onclick="tabPegin()">Liquid Peg-In</a></li>
-                  <li title="Withdrawal to an external address. Transaction fee rate can be bumped with {{if .CanRBF}}RBF{{else}}CPFP{{end}}." id="sendTab" ><a href="javascript:void(0);" onclick="tabSend()">Send Bitcoin</a></li>
+                  <li title="Withdrawal to an external address. Transaction fee rate can be bumped with {{if .CanRBF}}RBF{{else}}CPFP{{end}}." id="sendTab" ><a href="javascript:void(0);" onclick="tabSend()">Send BTC</a></li>
                 </ul>
               </div>
               <form id="myForm" autocomplete="off" action="/pegin" method="post" onsubmit="return confirmSubmit()">

--- a/cmd/psweb/templates/bitcoin.gohtml
+++ b/cmd/psweb/templates/bitcoin.gohtml
@@ -379,6 +379,8 @@
 
               function calculateTransactionFee() {
                 let peginAmount = Number(document.getElementById("peginAmount").value);
+                const isPegin = document.getElementById("isPegin").value == "true";
+
                 if (peginAmount < 1) {
                   document.getElementById("subtractfee").checked = false;
                 }
@@ -506,7 +508,7 @@
                   // reset peginAmount to selectedAmount
                   peginAmount = selectedAmount;
                   document.getElementById("peginAmount").value = selectedAmount;
-
+                  
                   // allow unselect all with one click
                   document.getElementById("unselectAll").textContent = selectedUtxoCount;
                   document.getElementById("unselectAll").style.visibility = "visible";
@@ -519,8 +521,7 @@
                   return;
                 }
                 
-                const sendAddress = document.getElementById("sendAddress").value;      
-                const isPegin = document.getElementById("isPegin").value == "true";
+                const sendAddress = document.getElementById("sendAddress").value;
                 
                 if (!isPegin) {
                   // identify send address type

--- a/cmd/psweb/templates/bitcoin.gohtml
+++ b/cmd/psweb/templates/bitcoin.gohtml
@@ -241,12 +241,12 @@
               </thead>
               <tbody>
               {{range .Outputs}}
-                <tr>
+                <tr id="{{.TxidStr}}:{{.OutputIndex}}">
                   <td id="utxoAddress" class="truncate"><a href="{{$.BitcoinApi}}/address/{{.Address}}" target="_blank">{{.Address}}</a></td>
                   <td style="text-align: right;">{{fmt (u .Confirmations)}}</td>
                   <td id="utxoAmount" style="text-align: right;">{{fmt (u .AmountSat)}}</td>
                   {{if eq $.PeginTxId ""}}
-                    <td><input type="checkbox" id="select" onchange="onSelect(this.checked, {{.AmountSat}})" name="selected_outputs[]" value="{{.TxidStr}}:{{.OutputIndex}}"></td>
+                    <td><input type="checkbox" id="select" onchange="onSelect(this.checked, {{.AmountSat}}, '{{.TxidStr}}:{{.OutputIndex}}')" name="selected_outputs[]" value="{{.TxidStr}}:{{.OutputIndex}}"></td>
                   {{end}}
                 </tr>
               {{end}}
@@ -282,6 +282,7 @@
                 var fields = document.querySelectorAll('#select');
                 fields.forEach(function(element) {
                   element.checked = true
+                  document.getElementById(element.value).classList.add('is-selected');
                 });
                 calculateTransactionFee();
               }
@@ -291,16 +292,18 @@
                 delayedCalculateTransactionFee();
               }
 
-              function onSelect(checked, amountStr) {
+              function onSelect(checked, amountStr, rowId) {
                 var amountInt = Number(amountStr);
                 if (checked) {
                   document.getElementById("peginAmount").value = Number(document.getElementById("peginAmount").value) + amountInt;
                   document.getElementById("subtractfee").checked = true;
+                  document.getElementById(rowId).classList.add('is-selected');
                 } else {
                   document.getElementById("peginAmount").value = Number(document.getElementById("peginAmount").value) - amountInt;
                   if (Number(document.getElementById("peginAmount").value)<=0) {
                     document.getElementById("peginAmount").value = "";
                   }
+                  document.getElementById(rowId).classList.remove('is-selected');
                 }
                 calculateTransactionFee();
               }
@@ -309,6 +312,7 @@
                 var fields = document.querySelectorAll('#select');
                 fields.forEach(function(element) {
                   element.checked = false
+                  document.getElementById(element.value).classList.remove('is-selected');
                 });
                 document.getElementById("unselectAll").style.visibility = "hidden";
                 document.getElementById("peginAmount").value = "";
@@ -358,6 +362,14 @@
 
               // Function to execute after a delay
               function delayedCalculateTransactionFee() {
+                  // unselect UTXOs
+                  var fields = document.querySelectorAll('#select');
+                  fields.forEach(function(element) {
+                    element.checked = false
+                    document.getElementById(element.value).classList.remove('is-selected');
+                  });
+                  document.getElementById("unselectAll").style.visibility = "hidden";
+
                   // Clear previous timer if it exists
                   clearTimeout(timerId);
 
@@ -366,7 +378,7 @@
               }
 
               function calculateTransactionFee() {
-                const peginAmount = Number(document.getElementById("peginAmount").value);
+                let peginAmount = Number(document.getElementById("peginAmount").value);
                 if (peginAmount < 1) {
                   document.getElementById("subtractfee").checked = false;
                 }
@@ -395,6 +407,12 @@
                   return;
                 }
 
+                // amount cannot exceed available balance
+                if (peginAmount > {{.BitcoinBalance}}) {
+                  document.getElementById('result').innerText = "Amount exceeds available BTC balance";
+                  return;
+                }
+
                 {{if .CanRBF}} 
                   // change is P2TR
                   let outputsP2TR = change; // Number of P2TR outputs
@@ -416,6 +434,7 @@
                 
                 // Get all table rows and convert NodeList to an array
                 let tableArray = Array.from(document.querySelectorAll("#utxoTable tbody tr"));  
+                let selectedAmount = 0;
 
                 // Iterate through table rows
                 tableArray.forEach(function(row) {
@@ -424,6 +443,9 @@
                     if (checkbox && checkbox.checked) {
                       // Increment selected UTXO count
                       selectedUtxoCount++;
+
+                      // increment selected amount
+                      selectedAmount += parseFloat(row.querySelector("#utxoAmount").textContent.replace(/,/g, ''));
                       
                       // identify P2TR vs P2WPKH address
                       const address = row.querySelector("#utxoAddress").textContent
@@ -434,6 +456,9 @@
                         // Increment P2WPKH UTXO count
                         inputsP2WPKH++;
                       }
+                    } else {
+                      // do not highlight what is not selected
+                      row.classList.remove('is-selected');
                     }
                 });
 
@@ -459,6 +484,9 @@
                     if (amountToAllocate > 0) {
                         // Reduce unallocated amount by UTXO size
                         amountToAllocate -= parseFloat(row.querySelector("#utxoAmount").textContent.replace(/,/g, ''));
+                        
+                        // highlight what is selected
+                        row.classList.add('is-selected');
 
                         // identify P2TR vs P2WPKH address
                         const address = row.querySelector("#utxoAddress").textContent
@@ -469,9 +497,16 @@
                           // Increment P2WPKH UTXO count
                           inputsP2WPKH++;
                         }
+                    } else {
+                      // do not highlight what is not selected
+                      row.classList.remove('is-selected');
                     }
                   });
                 } else {
+                  // reset peginAmount to selectedAmount
+                  peginAmount = selectedAmount;
+                  document.getElementById("peginAmount").value = selectedAmount;
+
                   // allow unselect all with one click
                   document.getElementById("unselectAll").textContent = selectedUtxoCount;
                   document.getElementById("unselectAll").style.visibility = "visible";

--- a/cmd/psweb/templates/liquid.gohtml
+++ b/cmd/psweb/templates/liquid.gohtml
@@ -30,7 +30,7 @@
           <div class="box has-text-left">
             <div style="display: grid; grid-template-columns: auto auto; padding-bottom: .5em;">
               <div style="text-align: left;">
-                <h4 class="title is-4">Liquid Auto Swap-In</h4>
+                <h4 class="title is-4">Liquid Auto Swap</h4>
               </div>
               <div style="display: flex; justify-content: flex-end;">
                 {{if .AutoSwapEnabled}}
@@ -97,7 +97,7 @@
                   <div class="control">
                     <label class="checkbox is-large">
                       <input type="checkbox" name="autoSwapEnabled" {{if .AutoSwapEnabled}}checked{{end}}>
-                      <strong>&nbsp&nbspEnable Liquid Auto Swap-In</strong>
+                      <strong>&nbsp&nbspEnable Liquid Auto Swap 🌊 ⇨ ⚡</strong>
                     </label>
                   </div>
                 </div>

--- a/cmd/psweb/templates/peer.gohtml
+++ b/cmd/psweb/templates/peer.gohtml
@@ -231,6 +231,9 @@
                                   const utxoAmount = parseFloat(row.querySelector("#utxoAmountBTC").textContent);
                                   amountToAllocate -= utxoAmount;
 
+                                  // each used UTXO increases total fee, which may need more UTXOs
+                                  amountToAllocate += 84 * feeRate;
+
                                   // identify P2TR vs P2WPKH address
                                   const address = row.querySelector("#utxoAddressBTC").textContent
                                   if (address.startsWith('bc1p') || address.startsWith('tb1p')) {
@@ -254,6 +257,10 @@
                             // peerswap spends dust change as extra fee
                             change = {{.BitcoinBalance}} - swapAmount - fee;
                             if (change < 1000) {
+                              if (change < 0) {
+                                document.getElementById('result').innerText = "Insufficient BTC balance to cover expected fee of " + formatWithThousandSeparators(fee) + " sats";
+                                return;
+                              }
                               fee += change;
                             }
                           } else {
@@ -288,6 +295,9 @@
                                   // Reduce unallocated amount by UTXO size
                                   const utxoAmount = Math.round(parseFloat(row.querySelector("#utxoAmountLBTC").textContent)*100000000, 0);
                                   amountToAllocate -= utxoAmount;
+
+                                  // each used UTXO increases total fee, which may need more UTXOs
+                                  amountToAllocate += 84 * feeRate;
 
                                   // increment inputs
                                   inputs++;


### PR DESCRIPTION
- Fix AutoFees stop working bug
- Fix AutoFees applied on startup before forwards history has been downloaded
- LND 0.18: Fix AutoFees reacting to temporary balance increase due to pendinng HTLCs
- Highlight outputs to be used for peg-in or BTC withdrawal
- Warn when BTC swap-in amount is unlikely to cover chain fee 
- Limit L-BTC swap-in amount to avoid excessive fee rate