### PR TITLE
v1.6.8

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,7 @@
             "program": "${workspaceFolder}/cmd/psweb/",
             "showLog": false,
             "envFile": "${workspaceFolder}/.env",
-            "args": ["-datadir", "/home/vlad/.peerswap2"]
+            //"args": ["-datadir", "/home/vlad/.peerswap2"]
         }
     ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## 1.6.8
 
 - AutoFees: do not change inbound fee during pending HTLCs
-- AutoFees: bump Low Liq Rate of the channel's rule on failed HTLCs  
+- AutoFees: bump Low Liq Rate of the channel's rule on failed HTLCs
+- AutoFees: avoid redundant fee rate updates
 
 ## 1.6.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Versions
 
+## 1.6.8
+
+- AutoFees: do not change inbound fee during pending HTLCs
+- AutoFees: bump Low Liq Rate of the channel's rule on failed HTLCs  
+
 ## 1.6.7
 
 - Fix AutoFees stop working bug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - AutoFees: do not change inbound fee during pending HTLCs
 - AutoFees: bump Low Liq Rate of the channel's rule on failed HTLCs
 - AutoFees: avoid redundant fee rate updates
+- Fix telegram bot errors by escaping message text as MarkdownV2
 
 ## 1.6.7
 

--- a/cmd/psweb/ln/cln.go
+++ b/cmd/psweb/ln/cln.go
@@ -1206,15 +1206,13 @@ func ApplyAutoFees() {
 		// set the new rate
 		if newFee != oldFee {
 			// check if the fee was already set
-			lastFee := LastAutoFeeLog(channelId, false)
-			if lastFee != nil {
-				if newFee == lastFee.NewRate {
-					continue
-				}
+			if lastFeeIsTheSame(channelId, newFee, false) {
+				continue
 			}
 
 			peerId := channelMap["peer_id"].(string)
-			if _, err = SetFeeRate(peerId, channelId, int64(newFee), false, false); err == nil {
+			_, err = SetFeeRate(peerId, channelId, int64(newFee), false, false)
+			if err == nil && !lastFeeIsTheSame(channelId, newFee, false) {
 				// log the last change
 				LogFee(channelId, oldFee, newFee, false, false)
 			}

--- a/cmd/psweb/ln/cln.go
+++ b/cmd/psweb/ln/cln.go
@@ -1087,6 +1087,10 @@ func SetFeeRate(peerNodeId string,
 		req.FeePPM = feeRate
 	}
 
+	if oldRate == int(feeRate) {
+		return oldRate, errors.New("rate was already set")
+	}
+
 	err = client.Request(&req, &res)
 	if err != nil {
 		log.Println("SetFeeRate:", err)

--- a/cmd/psweb/ln/cln.go
+++ b/cmd/psweb/ln/cln.go
@@ -1201,6 +1201,14 @@ func ApplyAutoFees() {
 
 		// set the new rate
 		if newFee != oldFee {
+			// check if the fee was already set
+			lastFee := LastAutoFeeLog(channelId, false)
+			if lastFee != nil {
+				if newFee == lastFee.NewRate {
+					continue
+				}
+			}
+
 			peerId := channelMap["peer_id"].(string)
 			if _, err = SetFeeRate(peerId, channelId, int64(newFee), false, false); err == nil {
 				// log the last change

--- a/cmd/psweb/ln/common.go
+++ b/cmd/psweb/ln/common.go
@@ -410,3 +410,14 @@ func saveSwapRabate(swapId string, rebate int64) {
 	// save rebate payment
 	SwapRebates[swapId] = rebate
 }
+
+// check if the last logged fee rate is the same as newFee
+func lastFeeIsTheSame(channelId uint64, newFee int, isInbound bool) bool {
+	lastFee := LastAutoFeeLog(channelId, isInbound)
+	if lastFee != nil {
+		if newFee == lastFee.NewRate {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/psweb/ln/lnd.go
+++ b/cmd/psweb/ln/lnd.go
@@ -1971,6 +1971,15 @@ func ApplyAutoFees() {
 				// do not lower fees during pending HTLCs
 				continue
 			}
+
+			// check if the fee was already set
+			lastFee := LastAutoFeeLog(ch.ChanId, false)
+			if lastFee != nil {
+				if newFee == lastFee.NewRate {
+					continue
+				}
+			}
+
 			_, err := SetFeeRate(peerId, ch.ChanId, int64(newFee), false, false)
 			if err == nil {
 				// log the last change

--- a/cmd/psweb/ln/lnd.go
+++ b/cmd/psweb/ln/lnd.go
@@ -1896,6 +1896,15 @@ func applyAutoFee(client lnrpc.LightningClient, channelId uint64, htlcFail bool)
 			// do not lower fees for temporary balance spikes due to pending HTLCs
 			return
 		}
+
+		// check if the fee was already set
+		lastFee := LastAutoFeeLog(channelId, false)
+		if lastFee != nil {
+			if newFee == lastFee.NewRate {
+				return
+			}
+		}
+
 		if old, err := SetFeeRate(peerId, channelId, int64(newFee), false, false); err == nil {
 			// log the last change
 			LogFee(channelId, old, newFee, false, false)

--- a/cmd/psweb/ln/lnd.go
+++ b/cmd/psweb/ln/lnd.go
@@ -1710,6 +1710,10 @@ func SetFeeRate(peerNodeId string,
 		}
 	}
 
+	if oldRate == int(feeRate) {
+		return oldRate, errors.New("rate was already set")
+	}
+
 	_, err = client.UpdateChannelPolicy(context.Background(), &req)
 	if err != nil {
 		log.Println("SetFeeRate:", err)
@@ -1969,10 +1973,9 @@ func ApplyAutoFees() {
 		}
 
 		oldFee := int(policy.FeeRateMilliMsat)
-		newFee := oldFee
 		liqPct := int((ch.LocalBalance + ch.UnsettledBalance) * 100 / r.Capacity)
 
-		newFee = calculateAutoFee(ch.ChanId, params, liqPct, oldFee)
+		newFee := calculateAutoFee(ch.ChanId, params, liqPct, oldFee)
 
 		// set the new rate
 		if newFee != oldFee {

--- a/cmd/psweb/main.go
+++ b/cmd/psweb/main.go
@@ -35,13 +35,12 @@ import (
 
 const (
 	// App version tag
-	version = "v1.6.7"
+	version = "v1.6.8"
 
 	// Swap Out reserves are hardcoded here:
 	// https://github.com/ElementsProject/peerswap/blob/c77a82913d7898d0d3b7c83e4a990abf54bd97e5/peerswaprpc/server.go#L105
 	swapOutChannelReserve = 5000
 	// https://github.com/ElementsProject/peerswap/blob/c77a82913d7898d0d3b7c83e4a990abf54bd97e5/swap/actions.go#L388
-	// increased by extra 1000 sats to avoid huge fee rate
 	swapOutChainReserve = 20300
 	// for Swap In reserves see /ln
 )

--- a/cmd/psweb/telegram.go
+++ b/cmd/psweb/telegram.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"peerswap-web/cmd/psweb/config"
@@ -105,7 +106,7 @@ func telegramStart() {
 					}
 				}
 				telegramSendMessage(t)
-			case "/auto":
+			case "/autoswaps":
 				t := "🤖 Auto swap-ins are "
 				if config.Config.AutoSwapEnabled {
 					t += "Enabled"
@@ -156,7 +157,7 @@ func telegramConnect() {
 				Description: "Status of peg-in or BTC withdrawal",
 			},
 			tgbotapi.BotCommand{
-				Command:     "auto",
+				Command:     "autoswaps",
 				Description: "Status of auto swap-ins",
 			},
 			tgbotapi.BotCommand{
@@ -177,7 +178,7 @@ func telegramSendMessage(msgText string) bool {
 	if chatId == 0 {
 		return false
 	}
-	msg := tgbotapi.NewMessage(chatId, msgText)
+	msg := tgbotapi.NewMessage(chatId, EscapeMarkdownV2(msgText))
 	msg.ParseMode = "MarkdownV2"
 
 	_, err := bot.Send(msg)
@@ -211,4 +212,29 @@ func telegramSendFile(folder, fileName, satAmount string) error {
 	}
 
 	return nil
+}
+
+// EscapeMarkdownV2 escapes special characters for MarkdownV2
+func EscapeMarkdownV2(text string) string {
+	replacer := strings.NewReplacer(
+		"_", "\\_",
+		"*", "\\*",
+		"[", "\\[",
+		"]", "\\]",
+		"(", "\\(",
+		")", "\\)",
+		"~", "\\~",
+		"`", "\\`",
+		">", "\\>",
+		"#", "\\#",
+		"+", "\\+",
+		"-", "\\-",
+		"=", "\\=",
+		"|", "\\|",
+		"{", "\\{",
+		"}", "\\}",
+		".", "\\.",
+		"!", "\\!",
+	)
+	return replacer.Replace(text)
 }


### PR DESCRIPTION
- AutoFees: do not change inbound fee during pending HTLCs
- AutoFees: bump Low Liq Rate of the channel's rule on failed HTLCs
- AutoFees: avoid redundant fee rate updates
- Fix telegram bot errors by escaping message text as MarkdownV2