### PR TITLE
v1.7.4

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,0 @@
-DEBUG=1
-NETWORK="testnet"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 push.sh
 cmd/psweb/__debug_bin*
+.env

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,7 @@
             "showLog": false,
             "envFile": "${workspaceFolder}/.env",
             //"args": ["-datadir", "/home/vlad/.peerswap_t4"]
-            "args": ["-datadir", "/home/vlad/.peerswap2"]
+            //"args": ["-datadir", "/home/vlad/.peerswap2"]
         }, 
         // sudo bash -c 'echo 0 > /proc/sys/kernel/yama/ptrace_scope'
         // go install -tags cln -gcflags 'all=-N -l' ./cmd/psweb

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,7 @@
             "showLog": false,
             "envFile": "${workspaceFolder}/.env",
             //"args": ["-datadir", "/home/vlad/.peerswap_t4"]
-            //"args": ["-datadir", "/home/vlad/.peerswap3"]
+            "args": ["-datadir", "/home/vlad/.peerswap2"]
         }, 
         // sudo bash -c 'echo 0 > /proc/sys/kernel/yama/ptrace_scope'
         // go install -tags cln -gcflags 'all=-N -l' ./cmd/psweb

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,7 @@
             "showLog": false,
             "envFile": "${workspaceFolder}/.env",
             //"args": ["-datadir", "/home/vlad/.peerswap_t4"]
-            //"args": ["-datadir", "/home/vlad/.peerswap2"]
+            "args": ["-datadir", "/home/vlad/.peerswap2"]
         }, 
         // sudo bash -c 'echo 0 > /proc/sys/kernel/yama/ptrace_scope'
         // go install -tags cln -gcflags 'all=-N -l' ./cmd/psweb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.7.4
 
 - Bump Go version to v1.22.2
+- Bypass BTC balance check for a pegin from external wallet
 
 ## 1.7.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Versions
 
+## 1.7.4
+
+- Bump Go version to v1.22.2
+
 ## 1.7.3
 
 - Show L-BTC balance changes when sending backup by telegram

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Bump Go version to v1.22.2
 - Bypass BTC balance check for a pegin from external wallet
+- Assume CT discounts on mainnet for Elements v23.02.03+
 
 ## 1.7.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,11 @@
 ## 1.7.4
 
 - Bump Go version to v1.22.2
-- Bypass BTC balance check for a pegin from external wallet
+- Bypass BTC balance check for a pegin from an external wallet
 - Assume CT discounts on mainnet for Elements v23.02.03+
+- Better predict swap cost for edge cases when change is under 1000 sats
+- Try to get tx fee from local Elements first
+- Warn of swap amount exceeding maximum
 
 ## 1.7.3
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 ## Build PeerSwap and PeerSwap Web UI in a joint container 
 ###
 
-FROM golang:1.21.5-bullseye AS builder
+FROM golang:1.22.2-bullseye AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/cmd/psweb/liquid/elements.go
+++ b/cmd/psweb/liquid/elements.go
@@ -409,10 +409,9 @@ func EstimateFee() float64 {
 func GetVersion() int {
 	client := ElementsClient()
 	service := &Elements{client}
-	wallet := config.Config.ElementsWallet
 	params := &[]string{}
 
-	r, err := service.client.call("getnetworkinfo", params, "/wallet/"+wallet)
+	r, err := service.client.call("getnetworkinfo", params, "")
 	if err = handleError(err, &r); err != nil {
 		log.Printf("Elements GetVersion error: %v", err)
 		return 0

--- a/cmd/psweb/liquid/elements.go
+++ b/cmd/psweb/liquid/elements.go
@@ -177,10 +177,14 @@ type UTXO struct {
 	Safe             bool    `json:"safe"`
 }
 
-func ListUnspent(outputs *[]UTXO) error {
+func ListUnspent(outputs *[]UTXO, assetId string) error {
 	client := ElementsClient()
 	service := &Elements{client}
-	params := []string{}
+	queryOptions := make(map[string]interface{})
+	if assetId != "" {
+		queryOptions["asset"] = assetId
+	}
+	params := []interface{}{1, 9999999, []string{}, true, queryOptions}
 	wallet := config.Config.ElementsWallet
 
 	r, err := service.client.call("listunspent", params, "/wallet/"+wallet)
@@ -242,10 +246,11 @@ func SendToAddress(address string,
 
 // Backup wallet and zip it with Elements Core password
 // .bak's name is equal to master blinding key
-func BackupAndZip(wallet string) (string, error) {
+func BackupAndZip() (string, error) {
 
 	client := ElementsClient()
 	service := &Elements{client}
+	wallet := config.Config.ElementsWallet
 
 	r, err := service.client.call("dumpmasterblindingkey", []string{}, "/wallet/"+wallet)
 	if err = handleError(err, &r); err != nil {
@@ -413,7 +418,6 @@ func GetVersion() int {
 
 	r, err := service.client.call("getnetworkinfo", params, "")
 	if err = handleError(err, &r); err != nil {
-		log.Printf("Elements GetVersion error: %v", err)
 		return 0
 	}
 
@@ -421,7 +425,6 @@ func GetVersion() int {
 
 	err = json.Unmarshal([]byte(r.Result), &response)
 	if err != nil {
-		log.Printf("Elements GetVersion error: %v", err)
 		return 0
 	}
 
@@ -473,11 +476,11 @@ func CreatePSET(params interface{}) (string, error) {
 	return response, nil
 }
 
-func ProcessPSET(base64psbt, wallet string) (string, bool, error) {
+func ProcessPSET(base64psbt string) (string, bool, error) {
 
 	client := ElementsClient()
 	service := &Elements{client}
-
+	wallet := config.Config.ElementsWallet
 	params := []interface{}{base64psbt}
 
 	r, err := service.client.call("walletprocesspsbt", params, "/wallet/"+wallet)
@@ -803,11 +806,11 @@ type AddressInfo struct {
 	Labels              []string `json:"labels"`
 }
 
-func GetAddressInfo(addr, wallet string) (*AddressInfo, error) {
+func GetAddressInfo(addr string) (*AddressInfo, error) {
 
 	client := ElementsClient()
 	service := &Elements{client}
-
+	wallet := config.Config.ElementsWallet
 	params := []interface{}{addr}
 
 	r, err := service.client.call("getaddressinfo", params, "/wallet/"+wallet)
@@ -897,10 +900,11 @@ type BalanceInfo struct {
 }
 
 // returns block hash
-func GetWalletInfo(wallet string) (*WalletInfo, error) {
+func GetWalletInfo() (*WalletInfo, error) {
 	client := ElementsClient()
 	service := &Elements{client}
 	params := &[]interface{}{}
+	wallet := config.Config.ElementsWallet
 
 	r, err := service.client.call("getwalletinfo", params, "/wallet/"+wallet)
 	if err = handleError(err, &r); err != nil {
@@ -919,11 +923,11 @@ func GetWalletInfo(wallet string) (*WalletInfo, error) {
 	return &response, nil
 }
 
-func GetNewAddress(label, addressType, wallet string) (string, error) {
+func GetNewAddress(label, addressType string) (string, error) {
 
 	client := ElementsClient()
 	service := &Elements{client}
-
+	wallet := config.Config.ElementsWallet
 	params := []interface{}{label, addressType}
 
 	r, err := service.client.call("getnewaddress", params, "/wallet/"+wallet)
@@ -941,4 +945,29 @@ func GetNewAddress(label, addressType, wallet string) (string, error) {
 	}
 
 	return response, nil
+}
+
+func DumpAssetLabels() (*map[string]string, error) {
+
+	client := ElementsClient()
+	service := &Elements{client}
+	wallet := config.Config.ElementsWallet
+
+	params := []interface{}{}
+
+	r, err := service.client.call("dumpassetlabels", params, "/wallet/"+wallet)
+	if err = handleError(err, &r); err != nil {
+		log.Printf("Failed to DumpAssetLabels: %v", err)
+		return nil, err
+	}
+
+	var response = make(map[string]string)
+
+	err = json.Unmarshal([]byte(r.Result), &response)
+	if err != nil {
+		log.Printf("DumpAssetLabels unmarshall: %v", err)
+		return nil, err
+	}
+
+	return &response, nil
 }

--- a/cmd/psweb/ln/claimjoin.go
+++ b/cmd/psweb/ln/claimjoin.go
@@ -182,7 +182,7 @@ create_pset:
 			if blinder == 0 {
 				// my output
 				log.Println(ClaimStatus)
-				claimPSET, _, err = liquid.ProcessPSET(claimPSET, config.Config.ElementsWallet)
+				claimPSET, _, err = liquid.ProcessPSET(claimPSET)
 				if err != nil {
 					log.Println("Unable to blind output, cancelling ClaimJoin:", err)
 					EndClaimJoin("", "Coordination failure")
@@ -246,7 +246,7 @@ create_pset:
 			if i == 0 {
 				// my input, last to sign
 				log.Println(ClaimStatus)
-				claimPSET, _, err = liquid.ProcessPSET(claimPSET, config.Config.ElementsWallet)
+				claimPSET, _, err = liquid.ProcessPSET(claimPSET)
 				if err != nil {
 					log.Println("Unable to sign input, cancelling ClaimJoin:", err)
 					EndClaimJoin("", "Initiator signing failure")
@@ -492,7 +492,7 @@ func Broadcast(fromNodeId string, message *Message) bool {
 					return false
 				}
 
-				addressInfo, err := liquid.GetAddressInfo(ClaimParties[0].Address, config.Config.ElementsWallet)
+				addressInfo, err := liquid.GetAddressInfo(ClaimParties[0].Address)
 				if err != nil {
 					return false
 				}
@@ -718,7 +718,7 @@ func Process(message *Message, senderNodeId string) {
 
 				// process my output
 				newClaimPSET := base64.StdEncoding.EncodeToString(msg.PSET)
-				newClaimPSET, _, err = liquid.ProcessPSET(newClaimPSET, config.Config.ElementsWallet)
+				newClaimPSET, _, err = liquid.ProcessPSET(newClaimPSET)
 				if err != nil {
 					log.Println("Unable to encode PSET:", err)
 					return
@@ -787,7 +787,7 @@ func Process(message *Message, senderNodeId string) {
 				}
 
 				// process my output
-				claimPSET, _, err = liquid.ProcessPSET(claimPSET, config.Config.ElementsWallet)
+				claimPSET, _, err = liquid.ProcessPSET(claimPSET)
 				if err != nil {
 					log.Println("Unable to process PSET:", err)
 					return
@@ -1377,7 +1377,7 @@ func verifyPSET(newClaimPSET string) bool {
 		}
 	}
 
-	addressInfo, err := liquid.GetAddressInfo(ClaimParties[0].Address, config.Config.ElementsWallet)
+	addressInfo, err := liquid.GetAddressInfo(ClaimParties[0].Address)
 	if err != nil {
 		return false
 	}

--- a/cmd/psweb/main.go
+++ b/cmd/psweb/main.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	// App VERSION tag
-	VERSION = "v1.7.3"
+	VERSION = "v1.7.4"
 	// Swap Out reserves are hardcoded here:
 	// https://github.com/ElementsProject/peerswap/blob/c77a82913d7898d0d3b7c83e4a990abf54bd97e5/peerswaprpc/server.go#L105
 	SWAP_OUT_CHANNEL_RESERVE = 5000
@@ -1208,12 +1208,8 @@ func checkPegin() {
 			}
 
 			if failed {
-				log.Println("Peg-in claim FAILED!")
-				log.Println("Mainchain TxId:", config.Config.PeginTxId)
-				log.Println("Raw tx:", rawTx)
-				log.Println("Proof:", proof)
-				log.Println("Claim Script:", config.Config.PeginClaimScript)
-				telegramSendMessage("❗ Peg-in claim FAILED! See log for details.")
+				log.Printf("Peg-in claim FAILED! Recover your funds manually with this command line:\n\nelements-cli claimpegin %s %s %s\n", rawTx, proof, config.Config.PeginClaimScript)
+				telegramSendMessage("❗ Peg-in claim FAILED! See log for instructions.")
 			} else {
 				log.Println("Peg-in complete! Liquid TxId:", txid)
 				telegramSendMessage("💸 Peg-in complete! Liquid TxId: `" + txid + "`")

--- a/cmd/psweb/templates/bitcoin.gohtml
+++ b/cmd/psweb/templates/bitcoin.gohtml
@@ -43,7 +43,7 @@ Amount is capped at remote channel balance to mimic brute force discovery" for="
                   <li title="Withdrawal to an external address. Transaction fee rate can be bumped with {{if .CanRBF}}RBF{{else}}CPFP{{end}}." id="sendTab" ><a href="javascript:void(0);" onclick="tabSend()">Send BTC</a></li>
                 </ul>
               </div>
-              <form id="myForm" autocomplete="off" action="/pegin" method="post" onsubmit="return confirmSubmit()">
+              <form id="myForm" autocomplete="off" action="/pegin" method="post" onsubmit="return handleFormSubmit(event)">
                 <input autocomplete="false" name="hidden" type="text" style="display:none;">
                 <div id="sendAddressField" class="field is-horizontal" style="display:none">
                   <div class="field-label is-normal">
@@ -58,7 +58,7 @@ Amount is capped at remote channel balance to mimic brute force discovery" for="
                     <label class="label">Amount</label>
                   </div>
                   <div class="field-body">
-                    <input class="input is-medium" type="number" oninput="uncheckSubtractFee()" id="peginAmount" name="peginAmount" min="1000" max="{{.BitcoinBalance}}" placeholder="₿ BTC Amount (sats)">
+                    <input class="input is-medium" type="number" oninput="uncheckSubtractFee()" id="peginAmount" name="peginAmount" min="1000" placeholder="₿ BTC Amount (sats)">
                   </div>
                 </div>
                 <div class="field is-horizontal">
@@ -390,6 +390,18 @@ Amount is capped at remote channel balance to mimic brute force discovery" for="
                 calculateTransactionFee();
               }
 
+              // bypass balance check for external funding
+              function handleFormSubmit(event) {
+                // Check which button triggered the form submission
+                const triggeredButton = event.submitter;
+                if (triggeredButton.id === 'externalButton') {
+                  // Bypass confirmSubmit
+                  return true;
+                }
+                // Call confirmSubmit for other buttons
+                return confirmSubmit();
+              }
+
               // warning message if fee bump is not possible
               function confirmSubmit() {
                 const fee = Number(document.getElementById("totalFee").value);
@@ -478,7 +490,7 @@ Amount is capped at remote channel balance to mimic brute force discovery" for="
 
                 // amount cannot exceed available balance
                 if (peginAmount > {{.BitcoinBalance}}) {
-                  document.getElementById('result').innerText = "Amount exceeds available BTC balance";
+                  document.getElementById('result').innerText = "Amount exceeds available BTC balance. Use external funding.";
                   return;
                 }
 

--- a/cmd/psweb/templates/peer.gohtml
+++ b/cmd/psweb/templates/peer.gohtml
@@ -123,20 +123,24 @@
                           return number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
                       }
                       
-                      function setMax() {
+                      function swapMaxAmount() {
                         if (document.getElementById("to").value == "ln") {
                           if (document.getElementById("from").value == "lbtc") {
-                            document.getElementById("swapAmount").value = {{.MaxLiquidSwapIn}}; 
+                            return {{.MaxLiquidSwapIn}}; 
                           } else {
-                            document.getElementById("swapAmount").value = {{.MaxBitcoinSwapIn}};
+                            return {{.MaxBitcoinSwapIn}};
                           }                      
                         } else {
                           if (document.getElementById("to").value == "btc") {
-                            document.getElementById("swapAmount").value = {{.MaxBitcoinSwapOut}};                     
+                            return {{.MaxBitcoinSwapOut}};                     
                           } else {
-                            document.getElementById("swapAmount").value = {{.MaxLiquidSwapOut}};
+                            return {{.MaxLiquidSwapOut}};
                           }
                         }
+                      }
+
+                      function setMax() {
+                        document.getElementById("swapAmount").value = swapMaxAmount();
                         calculateTransactionFee();
                       }
 
@@ -187,7 +191,7 @@
                         let fee = 0;
                         let feeRate = {{.MempoolFeeRate}}; // LBTC
                         let title = ""; 
-                        let change = 25000;
+                        let change = 0;
                         let asset = document.getElementById("from").value;
                         let discount = "";
                         let claimText = "";
@@ -212,20 +216,19 @@
                           document.getElementById('resultLabel').title = '';
                           return;
                         }
-                        
+
+                        // check max amount
+                        const maxAmount = swapMaxAmount();
+                        if (swapAmount > maxAmount) {
+                          document.getElementById('result').innerText = "Maximum Swap Amount is " + formatWithThousandSeparators(maxAmount) + " sats";
+                          document.getElementById('result').title = '';
+                          document.getElementById('resultLabel').title = '';
+                          return;
+                        }
+
                         if (document.getElementById("from").value != "ln") {
                           title = "Assumed UTXOs:\n";
                           if (asset == "btc") {
-                            // Check amount
-                            const maxAmount = {{.BitcoinBalance}} - {{.ReserveBTC}};
-                            if (swapAmount > maxAmount) {
-                              document.getElementById('result').innerText = "Insufficient BTC balance (only " + formatWithThousandSeparators(maxAmount) + " sats available for swap)";
-                              document.getElementById('result').innerText += "\nFee reserve: {{fmt .ReserveBTC}} sats";
-                              document.getElementById('result').title = '';
-                              document.getElementById('resultLabel').title = '';
-                              return;
-                            }
-
                             // Initialize total UTXO amount and UTXO counters
                             let totalUtxoAmount = 0;
                             let inputsP2TR = 0; // Number of P2TR inputs
@@ -248,24 +251,24 @@
                             tableArray.forEach(function(row) {
                               // Check if allocation is not finished
                               if (amountToAllocate >= 0) {
-                                  // Reduce unallocated amount by UTXO size
-                                  const utxoAmount = parseFloat(row.querySelector("#utxoAmountBTC").textContent);
-                                  amountToAllocate -= utxoAmount;
+                                // Reduce unallocated amount by UTXO size
+                                const utxoAmount = parseFloat(row.querySelector("#utxoAmountBTC").textContent);
+                                amountToAllocate -= utxoAmount;
 
-                                  // each used UTXO increases total fee, which may need more UTXOs
-                                  amountToAllocate += 84 * feeRate;
+                                // each used UTXO increases total fee, which may need more UTXOs
+                                amountToAllocate += 84 * feeRate;
 
-                                  // identify P2TR vs P2WPKH address
-                                  const address = row.querySelector("#utxoAddressBTC").textContent
-                                  if (address.startsWith('bc1p') || address.startsWith('tb1p')) {
-                                    // Increment P2TR UTXO count
-                                    inputsP2TR++;
-                                  } else {
-                                    // Increment P2WPKH UTXO count
-                                    inputsP2WPKH++;
-                                  }
-                                  title += "#" + formatWithThousandSeparators(inputsP2WPKH+inputsP2TR) + ": " + formatWithThousandSeparators(utxoAmount) + "\n";
-                              }
+                                // identify P2TR vs P2WPKH address
+                                const address = row.querySelector("#utxoAddressBTC").textContent
+                                if (address.startsWith('bc1p') || address.startsWith('tb1p')) {
+                                  // Increment P2TR UTXO count
+                                  inputsP2TR++;
+                                } else {
+                                  // Increment P2WPKH UTXO count
+                                  inputsP2WPKH++;
+                                }
+                                title += "#" + formatWithThousandSeparators(inputsP2WPKH+inputsP2TR) + ": " + formatWithThousandSeparators(utxoAmount) + "\n";
+                              } 
                             });
 
                             // calc fee
@@ -274,10 +277,10 @@
                             totalSize += 64 * inputsP2TR + 104 * inputsP2WPKH;
                             vbyteSize = 97 + Math.ceil((3 * baseSize + totalSize) / 4);
                             fee = vbyteSize * feeRate;
+                            change = Math.floor(-amountToAllocate);
 
-                            // peerswap spends dust change as extra fee
-                            change = {{.BitcoinBalance}} - swapAmount - fee;
                             if (change < 1000) {
+                              // peerswap spends dust change as extra fee
                               if (change < 0) {
                                 document.getElementById('result').innerText = "Insufficient BTC balance to cover expected fee of " + formatWithThousandSeparators(fee) + " sats";
                                 document.getElementById('result').title = '';
@@ -287,16 +290,6 @@
                               fee += change;
                             }
                           } else {
-                            // Check amount
-                            const maxAmount = {{.LiquidBalance}} - {{.ReserveLBTC}};
-                            if (swapAmount > maxAmount) {
-                              document.getElementById('result').innerText = "Insufficient L-BTC balance (only " + formatWithThousandSeparators(maxAmount) + " sats available for swap)";
-                              document.getElementById('result').innerText += "\nFee reserve: {{fmt .ReserveLBTC}} sats";
-                              document.getElementById('result').title = '';
-                              document.getElementById('resultLabel').title = '';
-                              return;
-                            }
-
                             // Initialize total UTXO amount and UTXO counters
                             let totalUtxoAmount = 0;
                             let inputs = 0; // Number of inputs
@@ -323,32 +316,41 @@
                                   amountToAllocate -= utxoAmount;
 
                                   // each used UTXO increases total fee, which may need more UTXOs
-                                  amountToAllocate += 84 * feeRate;
+                                  {{if .HasDiscountedvSize}}
+                                    amountToAllocate += 69 * feeRate;
+                                  {{else}}
+                                    amountToAllocate += 84 * feeRate;
+                                  {{end}}
 
                                   // increment inputs
                                   inputs++;
                                   title += "#" + formatWithThousandSeparators(inputs) + ": " + formatWithThousandSeparators(utxoAmount) + "\n";
                               }
                             });
-
+                            
                             // Calculate tx size assuming always two outputs
                             vbyteSize = 2420 + inputs * 84;
                             
                             {{if .HasDiscountedvSize}}
-                              vbyteSize = 284 + inputs * 69;
+                              // empirical discountvsize:
+                              // 1->2 269
+                              // 2->2 338 (= 1->2 + 69)
+                              // 3->2 406 (= 2->2 + 68)
+                              vbyteSize = 200 + inputs * 69;
                               discount =" discount";
                             {{end}}
 
                             fee = Math.ceil(vbyteSize * feeRate);
+                            change = Math.floor(-amountToAllocate);
 
-                            // elements spends dust change as extra fee
-                            change = {{.LiquidBalance}} - swapAmount - fee;
-
-                            // liquid dust size
-                            if (change < 500) {
+                            // elements spends dust change as extra fee     
+                            if (change < 1000) {
                               // one output only
                               {{if .HasDiscountedvSize}}
-                                vbyteSize -= 109;
+                                // 1->1 230 (= 1->2 - 39)
+                                // 2->1 271 (= 2->2 - 67)
+                                // 3->1 340 (= 3->2 - 66)
+                                vbyteSize -= 66;
                               {{else}}
                                 vbyteSize -= 1,191;
                               {{end}}
@@ -445,7 +447,7 @@
                       <textarea name="keysendMessage" class="textarea" rows="13">
 Dear {{.PeerAlias}}, 
 
-We are direct peers and could be using Liquid PeerSwap to rebalance our lightning channel. Recently, Liquid introduced discounted fee rates for confidential transactions. Now I can rebalance any amount for a flat fee of only 43 sats (swap in) or ~110 sats (swap out). Compare that to your circular rebalancing costs.
+We are direct peers and could be using Liquid PeerSwap to rebalance our lightning channel. Recently, Liquid introduced discounted fee rates for confidential transactions on mainnet. Now I can rebalance any amount for a flat fee of ~40 sats (swap in) or ~110 sats (swap out). Compare that to your circular rebalancing costs.
 
 PeerSwap is available for CLN and LND, including Umbrel App Store, and comes with an excellent Web UI. It allows sourcing L-BTC via confidential peg-ins, supports auto swap rebalancing and can manage channel fees. Check it out at https://github.com/Impa10r/peerswap-web.
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module peerswap-web
 
-go 1.21.5
+go 1.22.2
 
 // peerswap uses go-elements v0.4.0 which is not compatible with lnd v0.18
 // until they upgrade, I link to a compatible version in my repository


### PR DESCRIPTION
- Bump Go version to v1.22.2
- Bypass BTC balance check for a pegin from an external wallet
- Assume CT discounts on mainnet for Elements v23.02.03+
- Better predict swap cost for edge cases when change is under 1000 sats
- Try to get tx fee from local Elements first
- Warn of swap amount exceeding maximum