### PR TITLE
remove global premium from peer list and create dedicated page for it

### DIFF
--- a/cmd/psweb/main.go
+++ b/cmd/psweb/main.go
@@ -167,6 +167,7 @@ func start() {
 	r.HandleFunc("/pegin", peginHandler)
 	r.HandleFunc("/bumpfee", bumpfeeHandler)
 	r.HandleFunc("/ca", caHandler)
+	r.HandleFunc("/premiums", globalPremiumsHandler)
 	r.HandleFunc("/login", loginHandler)
 	r.HandleFunc("/logout", logoutHandler)
 	r.HandleFunc("/downloadca", downloadCaHandler)

--- a/cmd/psweb/templates/peer.gohtml
+++ b/cmd/psweb/templates/peer.gohtml
@@ -538,22 +538,6 @@ Sincerely,
                 <th style="text-align: center">⚡⇨🌊</th>
               </tr>
               <tr style="border: 1px dotted">
-                <td style="padding: 0px; text-align: center">Global</td>
-                {{range $i, $rate := .GlobalPremium}}
-                  <td style="padding: 0px; text-align: center">
-                    <form id="{{$i}}_default_premium" autocomplete="off" action="/submit" method="post">
-                      <input autocomplete="false" name="hidden" type="text" style="display:none;">
-                      <input type="hidden" name="action" value="setPremium">
-                      <input type="hidden" name="peerNodeId" value="">
-                      <input type="hidden" name="asset" value="{{ $rate.Asset }}">
-                      <input type="hidden" name="operation" value="{{ $rate.Operation }}">
-                      <input type="hidden" name="nextPage" value="/peer?id={{$.Peer.NodeId}}&">
-                      <input class="transparent-input" {{if eq $.ColorScheme "light"}}style="color: black"{{end}} type="number" name="premium" value="{{ $rate.PremiumRatePpm }}" onchange="submitForm('{{$i}}_default_premium')">
-                    </form>
-                  </td>
-                {{end}}
-              </tr>
-              <tr style="border: 1px dotted">
                 <td style="padding: 0px; text-align: center">For Peer</td>
                 {{range $i, $rate := .PeerPremium}}
                   <td style="padding: 0px; text-align: center">

--- a/cmd/psweb/templates/premiums.gohtml
+++ b/cmd/psweb/templates/premiums.gohtml
@@ -26,7 +26,7 @@
                 <input class="input is-medium has-text-centered" type="number" name="premium" value="{{.PremiumRatePpm}}" onchange="this.form.submit()" aria-label="Premium in parts-per-million">
               </div>
               <div class="control">
-                <a class="button is-medium is-static">PPM</a>
+                <a class="button is-medium is-static has-text-black">PPM</a>
               </div>
             </form>
           </div>

--- a/cmd/psweb/templates/premiums.gohtml
+++ b/cmd/psweb/templates/premiums.gohtml
@@ -1,0 +1,38 @@
+{{define "premiums"}}
+  {{template "header" .}}
+  <div class="container">
+    <div class="columns is-centered">
+      <div class="column is-three-quarters">
+        <div class="box has-text-centered">
+          <h3 class="title is-3">Global Premiums</h3>
+          <p class="subtitle is-6">Adjust the default swap premiums that apply to every peer. Values are expressed in parts-per-million (PPM).</p>
+        </div>
+      </div>
+    </div>
+    <div class="columns is-multiline">
+      {{range .Premiums}}
+        <div class="column is-half">
+          <div class="box has-text-centered">
+            <p class="title is-4">{{.Title}}</p>
+            <p class="subtitle is-6" style="min-height: 3em;">{{.Description}}</p>
+            <form id="{{.FormID}}" action="/submit" method="post" autocomplete="off" class="field has-addons has-addons-centered" style="justify-content: center;">
+              <input autocomplete="false" name="hidden" type="text" style="display:none;">
+              <input type="hidden" name="action" value="setPremium">
+              <input type="hidden" name="peerNodeId" value="">
+              <input type="hidden" name="asset" value="{{.Asset}}">
+              <input type="hidden" name="operation" value="{{.Operation}}">
+              <input type="hidden" name="nextPage" value="/premiums?">
+              <div class="control">
+                <input class="input is-medium has-text-centered" type="number" name="premium" value="{{.PremiumRatePpm}}" onchange="this.form.submit()" aria-label="Premium in parts-per-million">
+              </div>
+              <div class="control">
+                <a class="button is-medium is-static">PPM</a>
+              </div>
+            </form>
+          </div>
+        </div>
+      {{end}}
+    </div>
+  </div>
+  {{template "footer" .}}
+{{end}}

--- a/cmd/psweb/templates/reusable.gohtml
+++ b/cmd/psweb/templates/reusable.gohtml
@@ -34,6 +34,7 @@
                                 <a href="/bitcoin" class="dropdown-item"> Bitcoin Wallet </a>
                                 <a href="/liquid" class="dropdown-item"> Liquid Wallet </a>
                                 <a href="/af" class="dropdown-item"> Channel Fees </a>
+                                <a href="/premiums" class="dropdown-item"> Global Premiums </a>
                                 <hr class="dropdown-divider" />
                                 <a href="/config" class="dropdown-item"> Configuration </a>
                                 <a href="/log?log=psweb.log" class="dropdown-item"> Logs </a>


### PR DESCRIPTION

- remove the global premium data wiring from the peer view so it only exposes peer-specific rates
- add a globalPremiumsHandler and navigation entry for a dedicated /premiums page
- create a Bulma-styled premiums.gohtml template that surfaces the four global premium forms via the existing submit flow
